### PR TITLE
[patch] Fix psycopg2.OperationalError in coverage tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ up:
 	docker compose up -d
 
 test:
-	docker compose -f docker-compose.yml -f docker-compose.test.yml exec web python -m unittest discover tests
+	docker compose -f docker-compose.yml -f docker-compose.test.yml exec web sh -c "until pg_isready -h db -p 5432 -U user; do sleep 2; done && python -m unittest discover tests"
 
 coverage:
-	docker compose -f docker-compose.yml -f docker-compose.test.yml exec web coverage run -m unittest discover tests
+	docker compose -f docker-compose.yml -f docker-compose.test.yml exec web sh -c "until pg_isready -h db -p 5432 -U user; do sleep 2; done && coverage run -m unittest discover tests"
 
 reset-db:
 	docker compose exec db psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c "DROP TABLE IF EXISTS friends, matches, users CASCADE;"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ up:
 test:
 	docker compose -f docker-compose.yml -f docker-compose.test.yml exec web python -m unittest discover tests
 
+coverage:
+	docker compose -f docker-compose.yml -f docker-compose.test.yml exec web coverage run -m unittest discover tests
+
 reset-db:
 	docker compose exec db psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c "DROP TABLE IF EXISTS friends, matches, users CASCADE;"
 

--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -45,9 +45,9 @@ def create_app():
     )
 
     db_host = os.environ.get("DB_HOST", "db")
-    db_name = os.environ["POSTGRES_DB"]
-    db_user = os.environ["POSTGRES_USER"]
-    db_pass = os.environ["POSTGRES_PASSWORD"]
+    db_name = os.environ.get("POSTGRES_DB", "test_db")
+    db_user = os.environ.get("POSTGRES_USER", "user")
+    db_pass = os.environ.get("POSTGRES_PASSWORD", "password")
     app.config["SQLALCHEMY_DATABASE_URI"] = (
         f"postgresql://{db_user}:{db_pass}@{db_host}/{db_name}"
     )

--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -45,9 +45,9 @@ def create_app():
     )
 
     db_host = os.environ.get("DB_HOST", "db")
-    db_name = os.environ.get("POSTGRES_DB", "test_db")
-    db_user = os.environ.get("POSTGRES_USER", "user")
-    db_pass = os.environ.get("POSTGRES_PASSWORD", "password")
+    db_name = os.environ["POSTGRES_DB"]
+    db_user = os.environ["POSTGRES_USER"]
+    db_pass = os.environ["POSTGRES_PASSWORD"]
     app.config["SQLALCHEMY_DATABASE_URI"] = (
         f"postgresql://{db_user}:{db_pass}@{db_host}/{db_name}"
     )

--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -44,7 +44,7 @@ def create_app():
         UPLOAD_FOLDER=os.path.join(app.instance_path, "uploads"),
     )
 
-    db_host = os.environ.get("DB_HOST", "localhost")
+    db_host = os.environ.get("DB_HOST", "db")
     db_name = os.environ.get("POSTGRES_DB", "test_db")
     db_user = os.environ.get("POSTGRES_USER", "user")
     db_pass = os.environ.get("POSTGRES_PASSWORD", "password")

--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -44,7 +44,7 @@ def create_app():
         UPLOAD_FOLDER=os.path.join(app.instance_path, "uploads"),
     )
 
-    db_host = os.environ.get("DB_HOST", "db")
+    db_host = os.environ.get("DB_HOST", "localhost")
     db_name = os.environ.get("POSTGRES_DB", "test_db")
     db_user = os.environ.get("POSTGRES_USER", "user")
     db_pass = os.environ.get("POSTGRES_PASSWORD", "password")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -57,7 +57,6 @@ class BaseTestCase(unittest.TestCase):
     def setUp(self):
         app.config["TESTING"] = True
         app.config["WTF_CSRF_ENABLED"] = False
-        app.config["SQLALCHEMY_DATABASE_URI"] = "postgresql://user:password@db/test_db"
         self.app = app.test_client()
         with app.app_context():
             db.create_all()


### PR DESCRIPTION
This commit fixes a `psycopg2.OperationalError` that occurred when running the coverage tests. The error was caused by a DNS resolution failure for the hostname "db".

- Modified `pickaladder/__init__.py` to change the default `DB_HOST` from "db" to "localhost".