### PR TITLE
[minor] Add friend groups feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This document provides instructions for agents working on this project. By follo
 
 ## 1. High-Level Architectural Overview
 
-This is a monolithic web application built with **Flask**. The frontend is rendered server-side using **Jinja2 templates**. The application uses a **PostgreSQL** database, accessed directly via the `psycopg2` library (there is no ORM).
+This is a monolithic web application built with **Flask**. The frontend is rendered server-side using **Jinja2 templates**. The application uses a **PostgreSQL** database and the **SQLAlchemy ORM** (via the `Flask-SQLAlchemy` extension).
 
 The Flask application is organized into blueprints. The main application is configured in `pickaladder/__init__.py`.
 
@@ -16,7 +16,7 @@ When getting started, it's helpful to review these key files to understand the a
 
 *   `pickaladder/__init__.py`: The main Flask application factory. This is where the app is created and configured, and blueprints are registered.
 *   `init.sql`: The database schema. This is the source of truth for the database structure.
-*   `pickaladder/db.py`: Manages the database connection pool.
+*   `pickaladder/models.py`: Defines the SQLAlchemy database models.
 *   `pickaladder/auth/routes.py`: Handles user registration, login, and authentication logic.
 *   `pickaladder/user/routes.py`: Handles user profiles, friends, and other user-centric features.
 *   `pickaladder/match/routes.py`: Handles match creation and viewing the leaderboard.
@@ -46,8 +46,8 @@ When getting started, it's helpful to review these key files to understand the a
 *   **Keep Routes Thin:** Route handlers in the `routes.py` files should be kept as "thin" as possible. Complex business logic should be encapsulated in separate utility functions or, for larger features, dedicated service classes.
 
 ### Database
-*   **Beware N+1 Queries:** When fetching lists of items that have related data, be mindful of the N+1 query problem. Use SQL `JOIN`s to fetch all necessary data in a single, efficient query.
-*   **Parameterized Queries:** Always use `psycopg2`'s parameter substitution (`%s`) for query values to prevent SQL injection. For dynamic table or column names, validate them against a whitelist.
+*   **Use the ORM:** Use the SQLAlchemy ORM for all database interactions. The models are defined in `pickaladder/models.py`.
+*   **Beware N+1 Queries:** When fetching lists of items that have related data, be mindful of the N+1 query problem. Use SQLAlchemy's relationship loading strategies (e.g., `joinedload`, `subqueryload`) to fetch all necessary data in a single, efficient query.
 
 ### Security
 *   **CSRF Protection:** All forms and endpoints that perform state-changing actions (POST, PUT, DELETE requests) must be protected against Cross-Site Request Forgery (CSRF).

--- a/migrations/6_add_friend_groups_tables.sql
+++ b/migrations/6_add_friend_groups_tables.sql
@@ -1,0 +1,13 @@
+-- Create the friend_groups table
+CREATE TABLE friend_groups (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    owner_id UUID REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Create the friend_group_members table
+CREATE TABLE friend_group_members (
+    group_id UUID REFERENCES friend_groups(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    PRIMARY KEY (group_id, user_id)
+);

--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -75,6 +75,10 @@ def create_app():
 
     app.register_blueprint(match.bp)
 
+    from . import group
+
+    app.register_blueprint(group.bp)
+
     from . import error_handlers
 
     app.register_blueprint(error_handlers.error_handlers_bp)

--- a/pickaladder/group/__init__.py
+++ b/pickaladder/group/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("group", __name__, url_prefix="/group")
+
+from . import routes  # noqa: E402, F401

--- a/pickaladder/group/forms.py
+++ b/pickaladder/group/forms.py
@@ -1,0 +1,11 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, SelectField
+from wtforms.validators import DataRequired
+
+
+class FriendGroupForm(FlaskForm):
+    name = StringField("Group Name", validators=[DataRequired()])
+
+
+class InviteFriendForm(FlaskForm):
+    friend = SelectField("Friend", validators=[DataRequired()])

--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -1,0 +1,105 @@
+import uuid
+from flask import render_template, redirect, url_for, session, flash
+from sqlalchemy import or_, case, func
+from pickaladder import db
+from . import bp
+from .forms import FriendGroupForm, InviteFriendForm
+from pickaladder.models import FriendGroup, FriendGroupMember, User, Match
+from pickaladder.constants import USER_ID
+from pickaladder.auth.decorators import login_required
+
+
+@bp.route("/", methods=["GET"])
+@login_required
+def view_groups():
+    user_id = uuid.UUID(session[USER_ID])
+    user = User.query.get(user_id)
+    groups = user.group_memberships
+    return render_template("groups.html", groups=groups)
+
+
+@bp.route("/<uuid:group_id>", methods=["GET", "POST"])
+@login_required
+def view_group(group_id):
+    group = FriendGroup.query.get_or_404(group_id)
+    user_id = uuid.UUID(session[USER_ID])
+    user = User.query.get(user_id)
+
+    # --- Invite form logic ---
+    form = InviteFriendForm()
+    # Get user's accepted friends
+    friend_ids = [
+        f.friend_id for f in user.friend_requests_sent if f.status == "accepted"
+    ]
+    # Get current group members
+    member_ids = [m.user_id for m in group.members]
+    # Friends who are not already members
+    eligible_friends = User.query.filter(
+        User.id.in_(friend_ids), User.id.notin_(member_ids)
+    ).all()
+    form.friend.choices = [(str(f.id), f.name) for f in eligible_friends]
+
+    if form.validate_on_submit():
+        try:
+            friend_id = uuid.UUID(form.friend.data)
+            new_member = FriendGroupMember(group_id=group.id, user_id=friend_id)
+            db.session.add(new_member)
+            db.session.commit()
+            flash("Friend invited successfully.", "success")
+            return redirect(url_for("group.view_group", group_id=group.id))
+        except Exception as e:
+            db.session.rollback()
+            flash(f"An unexpected error occurred: {e}", "danger")
+
+    # --- Leaderboard logic ---
+    player_score = case(
+        (Match.player1_id == User.id, Match.player1_score),
+        else_=Match.player2_score,
+    )
+    leaderboard = (
+        db.session.query(
+            User.id,
+            User.name,
+            func.avg(player_score).label("avg_score"),
+            func.count(Match.id).label("games_played"),
+        )
+        .join(Match, or_(User.id == Match.player1_id, User.id == Match.player2_id))
+        .filter(User.id.in_(member_ids))
+        .filter(Match.player1_id.in_(member_ids))
+        .filter(Match.player2_id.in_(member_ids))
+        .group_by(User.id, User.name)
+        .order_by(func.avg(player_score).desc())
+        .all()
+    )
+
+    return render_template(
+        "group.html",
+        group=group,
+        leaderboard=leaderboard,
+        form=form,
+        current_user_id=user_id,
+    )
+
+
+@bp.route("/create", methods=["GET", "POST"])
+@login_required
+def create_group():
+    form = FriendGroupForm()
+    if form.validate_on_submit():
+        user_id = uuid.UUID(session[USER_ID])
+        try:
+            new_group = FriendGroup(name=form.name.data, owner_id=user_id)
+            db.session.add(new_group)
+            db.session.flush()  # Flush to get the new_group.id
+
+            # Add the owner as the first member
+            new_member = FriendGroupMember(group_id=new_group.id, user_id=user_id)
+            db.session.add(new_member)
+
+            db.session.commit()
+            flash("Group created successfully.", "success")
+            return redirect(url_for("group.view_group", group_id=new_group.id))
+        except Exception as e:
+            db.session.rollback()
+            flash(f"An unexpected error occurred: {e}", "danger")
+    return render_template("create_group.html", form=form)

--- a/pickaladder/models.py
+++ b/pickaladder/models.py
@@ -114,3 +114,33 @@ class Match(db.Model):  # type: ignore
 
     def __repr__(self):
         return f"<Match {self.id}>"
+
+
+class FriendGroup(db.Model):
+    __tablename__ = "friend_groups"
+    id = db.Column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.uuid_generate_v4()
+    )
+    name = db.Column(db.String, nullable=False)
+    owner_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
+
+    owner = db.relationship("User", backref="owned_groups")
+    members = db.relationship(
+        "FriendGroupMember", backref="group", cascade="all, delete-orphan"
+    )
+
+
+class FriendGroupMember(db.Model):
+    __tablename__ = "friend_group_members"
+    group_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("friend_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    user = db.relationship("User", backref="group_memberships")

--- a/pickaladder/templates/create_group.html
+++ b/pickaladder/templates/create_group.html
@@ -1,0 +1,16 @@
+{% extends "layout.html" %}
+{% block title %}Create Group{% endblock %}
+{% block content %}
+<div class="form-container">
+    <h2>Create New Friend Group</h2>
+    <form method="post" action="{{ url_for('group.create_group') }}">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+            {{ form.name.label }}
+            {{ form.name(class="form-control") }}
+        </div>
+        <input type="submit" value="Create Group" class="btn">
+        <a href="{{ url_for('group.view_groups') }}" class="btn btn-danger" style="margin-top: 10px;">Cancel</a>
+    </form>
+</div>
+{% endblock %}

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -1,0 +1,72 @@
+{% extends "layout.html" %}
+{% block title %}{{ group.name }}{% endblock %}
+{% block content %}
+<div class="page-header">
+    <h1>{{ group.name }}</h1>
+    <p>Owned by: {{ group.owner.username }}</p>
+</div>
+
+<div class="grid-container" style="grid-template-columns: 1fr 2fr; gap: 40px;">
+    <div class="card">
+        <h3>Members</h3>
+        <div class="table-container">
+            <table class="table">
+                <tbody>
+                    {% for member in group.members %}
+                    <tr class="clickable-row" data-href="{{ url_for('user.view_user', user_id=member.user.id) }}">
+                        <td>
+                            <img src="{{ url_for('user.profile_picture_thumbnail', user_id=member.user.id) }}"
+                                alt="Profile Picture" class="profile-picture-thumbnail">
+                        </td>
+                        <td>{{ member.user.username }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if group.owner_id == current_user_id %}
+        <h3 style="margin-top: 20px;">Invite Friends</h3>
+        <form method="post" action="{{ url_for('group.view_group', group_id=group.id) }}">
+            {{ form.hidden_tag() }}
+            <div class="form-group">
+                {{ form.friend.label }}
+                {{ form.friend(class="form-control") }}
+            </div>
+            <input type="submit" value="Invite" class="btn">
+        </form>
+        {% endif %}
+    </div>
+
+    <div class="card">
+        <h3>Group Leaderboard</h3>
+        <p>Only matches between group members are shown.</p>
+        <div class="table-container">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>Player</th>
+                        <th>Average Score</th>
+                        <th>Games Played</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for player in leaderboard %}
+                    <tr class="{{ 'highlight-row' if player.id == current_user_id else '' }}">
+                        <td>{{ loop.index }}</td>
+                        <td><a href="{{ url_for('user.view_user', user_id=player.id) }}">{{ player.name }}</a></td>
+                        <td>{{ "%.2f"|format(player.avg_score|float) }}</td>
+                        <td>{{ player.games_played }}</td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="4">No matches have been played between members of this group yet.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pickaladder/templates/groups.html
+++ b/pickaladder/templates/groups.html
@@ -1,0 +1,28 @@
+{% extends "layout.html" %}
+{% block title %}My Groups{% endblock %}
+{% block content %}
+<div class="page-header">
+    <h1>My Friend Groups</h1>
+    <a href="{{ url_for('group.create_group') }}" class="btn">Create New Group</a>
+</div>
+
+<div class="card">
+    <h3>Your Groups</h3>
+    <div class="table-container">
+        <table class="table">
+            <tbody>
+                {% for membership in groups %}
+                <tr class="clickable-row" data-href="{{ url_for('group.view_group', group_id=membership.group.id) }}">
+                    <td>{{ membership.group.name }}</td>
+                    <td>Owned by: {{ membership.group.owner.username }}</td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="2">You are not a member of any groups.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -12,6 +12,7 @@
                             <a href="{{ url_for('user.dashboard') }}">📈 Dashboard</a>
                             <a href="{{ url_for('user.users') }}">👥 Users</a>
                             <a href="{{ url_for('user.friends') }}">🧑‍🤝‍🧑 Friends</a>
+                            <a href="{{ url_for('group.view_groups') }}">👨‍👩‍👧‍👦 Groups</a>
                             <a href="{{ url_for('match.leaderboard') }}">🏆 Leaderboard</a>
                             <a href="{{ url_for('auth.change_password') }}">🔑 Change Password</a>
                             <a href="{{ url_for('auth.logout') }}">🚪 Logout</a>

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,0 +1,122 @@
+from tests.helpers import BaseTestCase, TEST_PASSWORD
+from pickaladder.models import Friend, FriendGroup, FriendGroupMember
+from pickaladder import db
+
+
+class GroupTestCase(BaseTestCase):
+    def test_create_group(self):
+        user = self.create_user(
+            username="group_creator",
+            password=TEST_PASSWORD,
+            is_admin=True,
+            email="group_creator@example.com",
+        )
+        self.login("group_creator", TEST_PASSWORD)
+        response = self.app.post(
+            "/group/create",
+            data={"name": "Test Group"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Group created successfully.", response.data)
+        group = FriendGroup.query.filter_by(name="Test Group").first()
+        self.assertIsNotNone(group)
+        self.assertEqual(group.owner_id, user.id)
+        # Check if the creator is a member
+        member = FriendGroupMember.query.filter_by(
+            group_id=group.id, user_id=user.id
+        ).first()
+        self.assertIsNotNone(member)
+
+    def test_invite_to_group(self):
+        owner = self.create_user(
+            username="group_owner_invite",
+            password=TEST_PASSWORD,
+            is_admin=True,
+            email="group_owner_invite@example.com",
+        )
+        friend_user = self.create_user(
+            username="friend_to_invite",
+            password=TEST_PASSWORD,
+            email="friend_to_invite@example.com",
+        )
+        # Establish friendship
+        friendship1 = Friend(
+            user_id=owner.id, friend_id=friend_user.id, status="accepted"
+        )
+        friendship2 = Friend(
+            user_id=friend_user.id, friend_id=owner.id, status="accepted"
+        )
+        db.session.add_all([friendship1, friendship2])
+        db.session.commit()
+
+        self.login("group_owner_invite", TEST_PASSWORD)
+        group = self.create_group(name="Invite Test Group", owner_id=owner.id)
+        self.add_user_to_group(group.id, owner.id)
+
+        response = self.app.post(
+            f"/group/{group.id}",
+            data={"friend": str(friend_user.id)},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Friend invited successfully.", response.data)
+        member = FriendGroupMember.query.filter_by(
+            group_id=group.id, user_id=friend_user.id
+        ).first()
+        self.assertIsNotNone(member)
+
+    def test_group_leaderboard(self):
+        owner = self.create_user(
+            username="leaderboard_owner",
+            name="Leaderboard Owner",
+            password=TEST_PASSWORD,
+            is_admin=True,
+            email="leaderboard_owner@example.com",
+        )
+        member1 = self.create_user(
+            username="leaderboard_member1",
+            name="Leaderboard Member 1",
+            password=TEST_PASSWORD,
+            email="leaderboard_member1@example.com",
+        )
+        member2 = self.create_user(
+            username="leaderboard_member2",
+            name="Leaderboard Member 2",
+            password=TEST_PASSWORD,
+            email="leaderboard_member2@example.com",
+        )
+        non_member = self.create_user(
+            username="non_member",
+            name="Non Member",
+            password=TEST_PASSWORD,
+            email="non_member@example.com",
+        )
+
+        group = self.create_group(name="Leaderboard Group", owner_id=owner.id)
+        self.add_user_to_group(group.id, owner.id)
+        self.add_user_to_group(group.id, member1.id)
+        self.add_user_to_group(group.id, member2.id)
+
+        # Match between group members (should be on leaderboard)
+        self.create_match(member1.id, member2.id, 11, 5)
+        # Match with a non-group member (should not be on leaderboard)
+        self.create_match(owner.id, non_member.id, 11, 2)
+
+        self.login("leaderboard_owner", TEST_PASSWORD)
+        response = self.app.get(f"/group/{group.id}")
+        self.assertEqual(response.status_code, 200)
+
+        # Member 1 should be on the leaderboard
+        self.assertIn(b"Leaderboard Member 1", response.data)
+        # Member 2 should be on the leaderboard
+        self.assertIn(b"Leaderboard Member 2", response.data)
+        # The owner should not be on the leaderboard yet (0 games played)
+        self.assertNotIn(b"Leaderboard Owner", response.data)
+        # The non-member should not be on the leaderboard
+        self.assertNotIn(b"Non Member", response.data)
+
+        # Check order
+        member1_pos = response.data.find(b"Leaderboard Member 1")
+        member2_pos = response.data.find(b"Leaderboard Member 2")
+        self.assertTrue(member1_pos < member2_pos)


### PR DESCRIPTION
This commit introduces a new feature that allows users to create and manage friend groups.

Key features include:
- Users can create new friend groups and give them a name.
- Group owners can invite their friends to join the group.
- Each group has its own page with a list of members and a group-specific leaderboard.
- The group leaderboard only shows rankings based on matches played between members of that group.

This change includes:
- New database tables `friend_groups` and `friend_group_members`.
- A new Flask blueprint for group-related routes.
- New templates for creating and viewing groups.
- A new test suite for the friend groups functionality.
- An update to the `AGENTS.md` documentation to reflect the use of SQLAlchemy.