### PR TITLE
[patch] Fix: Grant packages: write permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The GitHub Actions workflow was failing when trying to publish the Docker image to the GitHub Container Registry (ghcr.io). This was because the GITHUB_TOKEN used for authentication did not have the necessary `packages: write` permission.

This change adds the `permissions` key to the `deploy.yml` workflow file, explicitly granting `packages: write` and `contents: read` permissions to the `build-and-deploy` job. This will allow the workflow to successfully push the image to the container registry.