### PR TITLE
Fix: Refactor deployment to use Docker Compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,28 +43,35 @@ jobs:
           username: ${{ secrets.HOSTINGER_USERNAME }}
           key: ${{ secrets.HOSTINGER_SSH_KEY }}
           port: 22
-#          port: ${{ secrets.HOSTINGER_PORT }}
           script: |
+            # Login to GitHub Container Registry
             docker login ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
-            docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
-            docker network create app_default || true
-            docker stop app-web-1 || true
-            docker rm app-web-1 || true
-            docker run -d --restart always \
-              --network app_default \
-              -e SECRET_KEY=${{ secrets.SECRET_KEY }} \
-              -e MAIL_SERVER=${{ secrets.MAIL_SERVER }} \
-              -e MAIL_PORT=${{ secrets.MAIL_PORT }} \
-              -e MAIL_USE_TLS=${{ secrets.MAIL_USE_TLS }} \
-              -e MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} \
-              -e MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} \
-              -e POSTGRES_USER=${{ secrets.POSTGRES_USER }} \
-              -e POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} \
-              -e POSTGRES_DB=${{ secrets.POSTGRES_DB }} \
-              -e DB_HOST=${{ secrets.DB_HOST }} \
-              --name app-web-1 \
-              -p 27272:27272 \
-              ghcr.io/${{ github.repository }}:${{ github.sha }}
 
-            sleep 10 # Give the app time to start up before running migrations
-            docker exec app-web-1 python migrate.py
+            # Set environment variables for docker-compose
+            export IMAGE_TAG=ghcr.io/${{ github.repository }}:${{ github.sha }}
+            export SECRET_KEY='${{ secrets.SECRET_KEY }}'
+            export MAIL_SERVER='${{ secrets.MAIL_SERVER }}'
+            export MAIL_PORT='${{ secrets.MAIL_PORT }}'
+            export MAIL_USE_TLS='${{ secrets.MAIL_USE_TLS }}'
+            export MAIL_USERNAME='${{ secrets.MAIL_USERNAME }}'
+            export MAIL_PASSWORD='${{ secrets.MAIL_PASSWORD }}'
+            export POSTGRES_USER='${{ secrets.POSTGRES_USER }}'
+            export POSTGRES_PASSWORD='${{ secrets.POSTGRES_PASSWORD }}'
+            export POSTGRES_DB='${{ secrets.POSTGRES_DB }}'
+
+            # Ensure docker-compose is available
+            if ! command -v docker-compose &> /dev/null
+            then
+                echo "docker-compose could not be found, installing..."
+                sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                sudo chmod +x /usr/local/bin/docker-compose
+            fi
+
+            # Pull the latest images
+            docker-compose -f docker-compose.prod.yml pull
+
+            # Start the services
+            docker-compose -f docker-compose.prod.yml up -d --remove-orphans
+
+            # Clean up old images
+            docker image prune -f

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,51 @@
+services:
+  web:
+    image: ${IMAGE_TAG}
+    restart: always
+    ports:
+      - "27272:27272"
+    command: >
+      sh -c "
+        echo 'Waiting for DB to be ready...'
+        until pg_isready -h db -p 5432 -U ${POSTGRES_USER}; do
+          sleep 2
+        done
+        echo 'DB is ready, running migrations...'
+        python migrate.py
+        echo 'Migrations complete, starting app...'
+        gunicorn --bind 0.0.0.0:27272 --timeout 120 app:app
+      "
+    environment:
+      - SECRET_KEY=${SECRET_KEY}
+      - MAIL_SERVER=${MAIL_SERVER}
+      - MAIL_PORT=${MAIL_PORT}
+      - MAIL_USE_TLS=${MAIL_USE_TLS}
+      - MAIL_USERNAME=${MAIL_USERNAME}
+      - MAIL_PASSWORD=${MAIL_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - DB_HOST=db
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: postgres:13
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local


### PR DESCRIPTION
This commit fixes the deployment failures on Hostinger.

The previous deployment script used manual `docker` commands and failed to start the database container, causing a "Connection refused" error during migrations.

This has been resolved by:
1.  Introducing a `docker-compose.prod.yml` file to define the `web` and `db` services for the production environment. This file includes health checks and persistent volumes for the database.
2.  Updating the `.github/workflows/deploy.yml` script to use `docker-compose` for a more reliable and declarative deployment process. This aligns the production environment with the local development setup.