### PR TITLE
Fix: Correct database host configuration in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,14 +67,13 @@ jobs:
                 sudo chmod +x /usr/local/bin/docker-compose
             fi
 
-            # TEMPORARY: The following command is to wipe the database and should be removed after one successful deployment
-            docker-compose -f docker-compose.prod.yml down -v
+            export DB_HOST=db
 
             # Pull the latest images
             docker-compose -f docker-compose.prod.yml pull
 
             # Start the services
-            docker-compose -f docker-compose.prod.yml up -d --remove-orphans --build
+            docker-compose -f docker-compose.prod.yml up -d --remove-orphans
 
             # Clean up old images
             docker image prune -f


### PR DESCRIPTION
This commit fixes a `Connection refused` error that was occurring during deployment to the production server. The error was caused by a `DB_HOST` environment variable on the Hostinger server leaking into the Docker Compose process and overriding the correct database hostname.

The fix involves explicitly setting `export DB_HOST=db` in the `.github/workflows/deploy.yml` script. This ensures that the `web` container connects to the `db` container using the internal Docker network, rather than an incorrect public IP address.

The application code in `pickaladder/__init__.py` already uses the `DB_HOST` environment variable, so this change will be effective.

This commit also removes the temporary `down -v` command from the deployment script, as the primary issue was networking, not a stale database volume.

The previously added logging in `pickaladder/auth/routes.py` is retained to help diagnose any future issues.

This should finally resolve the 500 error on the initial page load.