### PR TITLE
Fix: Use an explicit Docker network to force container recreation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,8 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
-          no-cache: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Create project directory on server
         uses: appleboy/ssh-action@master

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - pickanet
   db:
     image: postgres:13
     restart: always
@@ -44,7 +46,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    networks:
+      - pickanet
 
 volumes:
   postgres_data:
     driver: local
+
+networks:
+  pickanet:
+    driver: bridge

--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -38,7 +38,7 @@ def create_app():
         UPLOAD_FOLDER=os.path.join(app.instance_path, "uploads"),
     )
 
-    db_host = "db"
+    db_host = os.environ.get("DB_HOST", "db")
     db_name = os.environ.get("POSTGRES_DB", "test_db")
     db_user = os.environ.get("POSTGRES_USER", "user")
     db_pass = os.environ.get("POSTGRES_PASSWORD", "password")


### PR DESCRIPTION
This commit implements a user suggestion to use an explicit Docker network. This is an attempt to resolve a persistent `Connection refused` error that suggests the production containers are not being updated correctly.

By defining a new network (`pickanet`) in `docker-compose.prod.yml` and attaching both the `web` and `db` services to it, we are forcing a configuration change that `docker-compose up` must act upon. This should guarantee that the containers are recreated, and that the new image with the correct code is used.

This commit also reverts several previous diagnostic changes:
- `pickaladder/__init__.py` is restored to use the `DB_HOST` environment variable.
- The `no-cache` option is removed from the deployment workflow, re-enabling the build cache for future deployments.

The one-time `down -v` command is still present in the deployment workflow to ensure a clean start for this deployment.