### PR TITLE
Fix: Add robust cleanup to deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,13 @@ jobs:
           script: |
             cd ~/picka-server
 
+            # Force stop any container using port 27272
+            CONTAINER_ID=$(docker ps -q --filter "publish=27272")
+            if [ -n "$CONTAINER_ID" ]; then
+              echo "Stopping container $CONTAINER_ID using port 27272"
+              docker stop $CONTAINER_ID
+            fi
+
             # Login to GitHub Container Registry
             docker login ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This commit resolves a `port is already allocated` error that was occurring during deployment. The error indicated that an old container was not being stopped correctly, preventing the new container from starting.

The `.github/workflows/deploy.yml` script has been updated to include a step that forcefully stops any container that is currently using the target port (27272) before attempting to bring up the new services.

This makes the deployment process more robust and ensures that old, lingering containers do not interfere with new deployments. This should be the final fix required to get the application running correctly.