### PR TITLE
fix: Add volume mapping for Firebase credentials in production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,9 @@ services:
     ports:
       - "27272:27272"
     command: gunicorn --bind 0.0.0.0:27272 --timeout 120 app:app
+    volumes:
+      # Mount the credentials file from the host into the container
+      - ./firebase-credentials.json:/app/firebase-credentials.json:ro
     environment:
       # These variables should be set in the production environment (e.g., GitHub Secrets)
       - SECRET_KEY=${SECRET_KEY}


### PR DESCRIPTION
This commit fixes a bug in the production deployment configuration. The `docker-compose.prod.yml` file was missing a volume mapping to mount the `firebase-credentials.json` file from the host server into the running container.

This resulted in a `google.auth.exceptions.DefaultCredentialsError: File /app/firebase-credentials.json was not found` error, preventing the application from starting correctly in the deployed environment.

This change adds the necessary volume mapping, ensuring the application can access its credentials and connect to Firebase.