### PR TITLE
fix: Correctly set GOOGLE_APPLICATION_CREDENTIALS in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,9 @@ services:
       # Mount the credentials file from the host into the container
       - ./firebase-credentials.json:/app/firebase-credentials.json:ro
     environment:
+      # GOOGLE_APPLICATION_CREDENTIALS should point to the path of the
+      # service account key file, which will be loaded into the container.
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/firebase-credentials.json
       # These variables should be set in the production environment (e.g., GitHub Secrets)
       - SECRET_KEY=${SECRET_KEY}
       - MAIL_SERVER=${MAIL_SERVER}


### PR DESCRIPTION
This commit fixes a bug in the `docker-compose.prod.yml` file where the `GOOGLE_APPLICATION_CREDENTIALS` environment variable was incorrectly placed in the `volumes` section instead of the `environment` section.

This prevented the application from finding the Firebase credentials file, even when it was correctly mounted into the container, leading to a `CONFIGURATION_NOT_FOUND` error on startup.

This change moves the variable to the correct `environment` section, ensuring the application can locate and use the credentials file in the production environment.