### PR TITLE
Fix: Remove duplicate environment variable in docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,9 +20,6 @@ services:
       - MAIL_USERNAME=${MAIL_USERNAME}
       - MAIL_PASSWORD=${MAIL_PASSWORD}
       - FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
-      # GOOGLE_APPLICATION_CREDENTIALS should point to the path of the
-      # service account key file, which will be loaded into the container.
-      - GOOGLE_APPLICATION_CREDENTIALS=/app/firebase-credentials.json
     networks:
       - pickanet
 


### PR DESCRIPTION
The deployment was failing due to a duplicate `GOOGLE_APPLICATION_CREDENTIALS` environment variable in the `docker-compose.prod.yml` file. This commit removes the duplicate entry to resolve the issue.