### PR TITLE
fix(auth): Convert DUPR rating to float for Firestore

### DIFF
--- a/pickaladder/auth/routes.py
+++ b/pickaladder/auth/routes.py
@@ -47,7 +47,7 @@ def register():
                     "username": username,
                     "email": email,
                     "name": form.name.data,
-                    "duprRating": form.dupr_rating.data,
+                    "duprRating": float(form.dupr_rating.data),
                     "isAdmin": False,
                     "createdAt": firestore.SERVER_TIMESTAMP,
                 }


### PR DESCRIPTION
The registration process was failing because the `dupr_rating` field, which comes from a `DecimalField` in the registration form, was being passed as a Python `Decimal` type to Firestore. Firestore does not support the `Decimal` type, which resulted in a `TypeError` during user creation.

This commit resolves the issue by explicitly converting the `form.dupr_rating.data` value to a `float` before it is set in the user document. This ensures the data is in a Firestore-compatible format.