### PR TITLE
fix(auth): Resolve client-side authentication timing issue

### DIFF
--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -47,19 +47,6 @@
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);
 
-        firebase.auth().onAuthStateChanged(function(user) {
-            if (user) {
-                user.getIdToken().then(function(idToken) {
-                    localStorage.setItem('firebaseIdToken', idToken);
-                    // If the user is on the login page and they are logged in, redirect them to the dashboard.
-                    if (window.location.pathname === '/login' || window.location.pathname === '/') {
-                        window.location.href = "{{ url_for('user.dashboard') }}";
-                    }
-                });
-            } else {
-                localStorage.removeItem('firebaseIdToken');
-            }
-        });
 
         // Intercept fetch to add the auth token
         const originalFetch = window.fetch;

--- a/pickaladder/templates/login.html
+++ b/pickaladder/templates/login.html
@@ -44,7 +44,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 return user.getIdToken();
             })
             .then((idToken) => {
-                // The onAuthStateChanged listener in layout.html will handle the redirect.
+                localStorage.setItem('firebaseIdToken', idToken);
+                setTimeout(() => {
+                    window.location.href = "{{ url_for('user.dashboard') }}";
+                }, 100);
             })
             .catch((error) => {
                 const errorCode = error.code;


### PR DESCRIPTION
This commit fixes a subtle timing issue in the client-side authentication flow that was preventing users from logging in. The `onAuthStateChanged` listener was creating a race condition with the login form's redirect logic.

The fix involves:
- Removing the `onAuthStateChanged` listener from `layout.html`.
- Restoring the redirect logic to the `login.html` template, with a small delay to ensure the authentication token is stored before the redirect.

This ensures a more reliable login experience for the user.