### PR TITLE
Fix CSRF token missing in login request

### DIFF
--- a/pickaladder/templates/login.html
+++ b/pickaladder/templates/login.html
@@ -46,6 +46,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
+                        "X-CSRFToken": document.querySelector('meta[name="csrf-token"]').getAttribute('content')
                     },
                     body: JSON.stringify({ idToken: idToken }),
                 });


### PR DESCRIPTION
This commit fixes a CSRF error that occurred during login. The client-side JavaScript was not including the CSRF token in the request to the `/auth/session_login` endpoint.

The fix involves:
- Updating the JavaScript in `login.html` to read the CSRF token from the meta tag and include it as a header in the `fetch` request.
- Updating the tests in `tests/test_auth.py` to work with CSRF protection enabled.