### PR TITLE
fix(auth): Resolve SyntaxError in firebase_config endpoint

### DIFF
--- a/pickaladder/auth/routes.py
+++ b/pickaladder/auth/routes.py
@@ -237,18 +237,3 @@ def firebase_config():
     }
     js_config = f"const firebaseConfig = {json.dumps(config)};"
     return Response(js_config, mimetype='application/javascript')
-    config = f"""
-const firebaseConfig = {{
-  apiKey: "{api_key}",
-    config = f"""
-const firebaseConfig = {{
-  apiKey: "{os.environ.get("FIREBASE_API_KEY")}",
-  authDomain: "pickaladder.firebaseapp.com",
-  projectId: "pickaladder",
-  storageBucket: "pickaladder.appspot.com",
-  messagingSenderId: "402457219675",
-  appId: "1:402457219675:web:a346e2dc0dfa732d31e57e",
-  measurementId: "G-E28CXCXTSK"
-}};
-"""
-    return Response(config, mimetype='application/javascript')


### PR DESCRIPTION
Removed a block of malformed, unreachable JavaScript code from the firebase_config function in pickaladder/auth/routes.py. This extraneous code was causing a SyntaxError on application startup, preventing the gunicorn worker from booting.