### PR TITLE
Fix: Pass FIREBASE_API_KEY to production environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,7 @@ jobs:
             export MAIL_USERNAME='${{ secrets.MAIL_USERNAME }}'
             export MAIL_PASSWORD='${{ secrets.MAIL_PASSWORD }}'
             export FIREBASE_PROJECT_ID='${{ secrets.FIREBASE_PROJECT_ID }}'
+            export FIREBASE_API_KEY='${{ secrets.FIREBASE_API_KEY }}'
 
             # Tear down the old environment to ensure a clean start
             docker-compose -f docker-compose.prod.yml down

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,6 +20,7 @@ services:
       - MAIL_USERNAME=${MAIL_USERNAME}
       - MAIL_PASSWORD=${MAIL_PASSWORD}
       - FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
+      - FIREBASE_API_KEY=${FIREBASE_API_KEY}
     networks:
       - pickanet
 


### PR DESCRIPTION
The application was failing at runtime because the `FIREBASE_API_KEY` was missing in the production container.

This commit fixes the issue by:
1.  Updating `docker-compose.prod.yml` to include the `FIREBASE_API_KEY` in the environment variables passed to the service.
2.  Updating the `.github/workflows/deploy.yml` deployment script to export the `FIREBASE_API_KEY` secret, making it available to the `docker-compose` command on the server.