### PR TITLE
fix: Ensure latest Docker image is used in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,14 +95,8 @@ jobs:
             export IMGUR_CLIENT_ID='${{ secrets.IMGUR_CLIENT_ID }}'
             export APP_VERSION='${{ github.sha }}'
 
-            # Tear down the old environment to ensure a clean start
-            docker-compose -f docker-compose.prod.yml down
-
-            # Pull the latest image
-            docker-compose -f docker-compose.prod.yml pull
-
-            # Start the services
-            docker-compose -f docker-compose.prod.yml up -d --remove-orphans
+            # Recreate the services, pulling the latest image
+            docker-compose -f docker-compose.prod.yml up -d --pull --remove-orphans
 
             # Clean up old images
             docker image prune -f


### PR DESCRIPTION
This commit fixes a deployment issue where the application was not running the latest version of the code, causing a circular import error at runtime.

The deployment script in `.github/workflows/deploy.yml` was not correctly pulling the new Docker image that was being built and pushed for each commit. This resulted in the server running a stale, cached image with the old, buggy code.

The script has been updated to use a single, atomic `docker-compose up -d --pull` command. This forces docker-compose to pull the latest image for all services before starting them, ensuring that the correct version of the application is always deployed.