### PR TITLE
feat: refactor versioning to use pull requests

### DIFF
--- a/.github/workflows/beta-version-update.yml
+++ b/.github/workflows/beta-version-update.yml
@@ -1,4 +1,4 @@
-name: Production Version Update
+name: Beta Version Update
 
 on:
   push:
@@ -7,30 +7,6 @@ on:
 
 jobs:
   update-version:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.9'
-
-      - name: Get next version
-        id: version
-        run: |
-          # Simple versioning: use the commit SHA for now
-          echo "::set-output name=version::${{ github.sha }}"
-
-      - name: Update version file
-        run: echo ${{ steps.version.outputs.version }} > VERSION
-
-      - name: Commit and push version update
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore: update version to ${{ steps.version.outputs.version }}"
-          branch: beta
-          file_pattern: VERSION
+    uses: ./.github/workflows/reusable-version-update.yml
+    with:
+      branch: beta

--- a/.github/workflows/production-version-update.yml
+++ b/.github/workflows/production-version-update.yml
@@ -7,30 +7,6 @@ on:
 
 jobs:
   update-version:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.9'
-
-      - name: Get next version
-        id: version
-        run: |
-          # Simple versioning: use the commit SHA for now
-          echo "::set-output name=version::${{ github.sha }}"
-
-      - name: Update version file
-        run: echo ${{ steps.version.outputs.version }} > VERSION
-
-      - name: Commit and push version update
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore: update version to ${{ steps.version.outputs.version }}"
-          branch: main
-          file_pattern: VERSION
+    uses: ./.github/workflows/reusable-version-update.yml
+    with:
+      branch: main

--- a/.github/workflows/reusable-version-update.yml
+++ b/.github/workflows/reusable-version-update.yml
@@ -1,0 +1,36 @@
+name: Reusable Version Update
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Get next version
+        id: version
+        run: echo "version=${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Update version file
+        run: echo "${{ steps.version.outputs.version }}" > VERSION
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(version): update to ${{ steps.version.outputs.version }}"
+          title: "chore(version): update to ${{ steps.version.outputs.version }}"
+          body: "This is an automated PR to update the version to `${{ steps.version.outputs.version }}`."
+          branch: "chore/version-update-${{ steps.version.outputs.version }}"
+          base: "${{ inputs.branch }}"
+          delete-branch: true


### PR DESCRIPTION
This commit refactors the versioning workflow to create a pull request instead of pushing directly to a protected branch. This change prevents the 'protected branch update failed' error and aligns the versioning process with the repository's security policies.

Key changes:
- A new reusable workflow, 'reusable-version-update.yml', has been created to handle the version update and pull request creation.
- The 'production-version-update.yml' and 'beta-version-update.yml' workflows have been updated to use the new reusable workflow.
- The 'stefanzweifel/git-auto-commit-action' has been replaced with the 'peter-evans/create-pull-request' action to enable this change.