### PR TITLE
fix: Refactor profile update logic to save user settings

### DIFF
--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -15,7 +15,7 @@
 
                 <hr>
                 <h4 style="margin-top: 20px;">Update Profile</h4>
-                <form method="post" action="{{ url_for('user.update_profile') }}" enctype="multipart/form-data">
+                <form method="post" action="{{ url_for('user.dashboard') }}" enctype="multipart/form-data">
                     {{ form.hidden_tag() }}
                     <div class="form-group">
                         {{ form.dupr_rating.label }}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -30,6 +30,9 @@ class AdminRoutesTestCase(unittest.TestCase):
             "admin_routes_firestore": patch(
                 "pickaladder.admin.routes.firestore", new=self.mock_firestore_service
             ),
+            "user_routes_firestore": patch(
+                "pickaladder.user.routes.firestore", new=self.mock_firestore_service
+            ),
         }
 
         self.mocks = {name: p.start() for name, p in patchers.items()}

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -35,6 +35,9 @@ class MatchRoutesFirebaseTestCase(unittest.TestCase):
             "auth_routes_firestore": patch(
                 "pickaladder.auth.routes.firestore", new=self.mock_firestore_service
             ),
+            "user_routes_firestore": patch(
+                "pickaladder.user.routes.firestore", new=self.mock_firestore_service
+            ),
             "verify_id_token": patch("firebase_admin.auth.verify_id_token"),
         }
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -77,7 +77,7 @@ class UserRoutesFirebaseTestCase(unittest.TestCase):
         mock_user_doc = self._mock_firestore_user()
 
         response = self.client.post(
-            "/user/update_profile",
+            "/user/dashboard",
             data={"dark_mode": "y", "dupr_rating": 5.5},
             follow_redirects=True,
         )
@@ -101,7 +101,7 @@ class UserRoutesFirebaseTestCase(unittest.TestCase):
 
         data = {"profile_picture": (BytesIO(b"test_image_data"), "test.png")}
         response = self.client.post(
-            "/user/update_profile",
+            "/user/dashboard",
             data=data,
             content_type="multipart/form-data",
             follow_redirects=True,
@@ -121,7 +121,7 @@ class UserRoutesFirebaseTestCase(unittest.TestCase):
         mock_user_doc = self._mock_firestore_user()
 
         response = self.client.post(
-            "/user/update_profile",
+            "/user/dashboard",
             data={"dark_mode": "y", "dupr_rating": "5.5"},
             follow_redirects=True,
         )


### PR DESCRIPTION
The user profile updates, including dark mode and DUPR rating, were not being saved. This was because the form was being submitted to a separate `/update_profile` route that was not correctly wired up.

The fix consolidates the profile update logic into the `/dashboard` route, which now handles both `GET` and `POST` requests. The `user_dashboard.html` template and relevant tests have been updated to reflect this change.