### PR TITLE
fix: Corrects checkout action version in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@vv5
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update version


### PR DESCRIPTION
This commit fixes a typo in the `.github/workflows/main.yml` file, changing `actions/checkout@vv5` to the correct `actions/checkout@v5`. This resolves the `Error: Unable to resolve action` error and allows the CI pipeline to run successfully.