### PR TITLE
fix: Create pull request instead of pushing to protected branch

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -28,5 +28,6 @@ jobs:
     if: needs.trigger_check.outputs.should_run == 'true'
     permissions:
       contents: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-versioning.yml
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,5 +28,6 @@ jobs:
     if: needs.trigger_check.outputs.should_run == 'true'
     permissions:
       contents: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-versioning.yml
     secrets: inherit

--- a/.github/workflows/reusable-versioning.yml
+++ b/.github/workflows/reusable-versioning.yml
@@ -26,10 +26,12 @@ jobs:
         run: |
           echo ${{ steps.version.outputs.VERSION }} > VERSION
 
-      - name: Commit and push changes
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add VERSION
-          git commit -m "chore: update version to ${{ steps.version.outputs.VERSION }} [skip ci]"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(version): update to ${{ steps.version.outputs.VERSION }}"
+          title: "Update version to ${{ steps.version.outputs.VERSION }}"
+          body: "This PR updates the application version to `${{ steps.version.outputs.VERSION }}`."
+          branch: "chore/version-update-${{ steps.version.outputs.VERSION }}"
+          base: "${{ github.ref_name }}"


### PR DESCRIPTION
This commit modifies the `reusable-versioning.yml` workflow to create a pull request with the updated `VERSION` file instead of pushing directly to the `main` and `beta` branches. This avoids the "protected branch update failed" error.

The `main.yml` and `beta.yml` workflows have also been updated to grant the `versioning` job the necessary `pull-requests: write` permission.