### PR TITLE
fix: Correct CI permissions and user data handling

### DIFF
--- a/.github/workflows/reusable-versioning.yml
+++ b/.github/workflows/reusable-versioning.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/pickaladder/user/routes.py
+++ b/pickaladder/user/routes.py
@@ -107,7 +107,10 @@ def dashboard():
     user_ref = db.collection("users").document(user_id)
     user_data = g.user
 
-    form = UpdateProfileForm(data=user_data)
+    form = UpdateProfileForm()
+    if request.method == "GET":
+        form.dupr_rating.data = user_data.get("duprRating")
+        form.dark_mode.data = user_data.get("darkMode")
 
     if form.validate_on_submit():
         try:


### PR DESCRIPTION
This commit addresses several issues:

1.  **CI/CD:**
    *   The `reusable-versioning.yml` workflow is updated to create a pull request instead of pushing directly to a protected branch.
    *   The `main.yml` and `beta.yml` workflows are updated to grant the `versioning` job the necessary `pull-requests: write` permission.
    *   The `reusable-versioning.yml` workflow is updated to explicitly declare the `pull-requests: write` permission.

2.  **Bug Fix:**
    *   The `dashboard` route in `pickaladder/user/routes.py` is updated to only populate the `UpdateProfileForm` on GET requests. This prevents the form from being pre-populated with old data on POST requests, which was overriding the submitted form data and preventing the user's changes from being saved.