### PR TITLE
Refactor dark mode implementation and fix CSS scoping

### DIFF
--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -1,8 +1,4 @@
-a {
-    color: #4dabf7;
-}
-
-:root {
+.dark-mode {
     --background-color: #121212;
     --surface-color: #1E1E1E;
     --on-primary-color: #ffffff;
@@ -11,43 +7,47 @@ a {
     --border-color: #333333;
 }
 
+.dark-mode a {
+    color: #4dabf7;
+}
+
 /* Some inputs might need specific overrides if they use background-color */
-input[type="text"],
-input[type="password"],
-input[type="email"],
-input[type="number"],
-input[type="date"],
-select {
+.dark-mode input[type="text"],
+.dark-mode input[type="password"],
+.dark-mode input[type="email"],
+.dark-mode input[type="number"],
+.dark-mode input[type="date"],
+.dark-mode select {
     background-color: var(--surface-color);
     color: var(--on-surface-color);
     border-color: var(--border-color);
 }
 
-.table th {
+.dark-mode .table th {
     background-color: #2c2c2c;
 }
 
-.clickable-row:hover {
+.dark-mode .clickable-row:hover {
     background-color: #2c2c2c;
 }
 
-.dropdown-content a:hover {
+.dark-mode .dropdown-content a:hover {
     background-color: #2c2c2c;
 }
 
-.alert-danger {
+.dark-mode .alert-danger {
     color: #f8d7da;
     background-color: #721c24;
     border-color: #f5c6cb;
 }
 
-.alert-success {
+.dark-mode .alert-success {
     color: #d4edda;
     background-color: #155724;
     border-color: #c3e6cb;
 }
 
-.admin-banner {
+.dark-mode .admin-banner {
     background-color: #0d47a1;
     color: var(--on-surface-color);
 }

--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -132,6 +132,7 @@ select {
     box-sizing: border-box;
     font-size: 16px;
     background-color: var(--background-color);
+    color: var(--on-surface-color);
 }
 
 input[type="text"]:focus,
@@ -447,10 +448,10 @@ input[type="submit"], .btn {
 }
 
 .modal-content {
-    background-color: #fefefe;
+    background-color: var(--surface-color);
     margin: 15% auto;
     padding: 20px;
-    border: 1px solid #888;
+    border: 1px solid var(--border-color);
     width: 80%;
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
@@ -470,7 +471,7 @@ input[type="submit"], .btn {
 }
 
 .close {
-    color: #aaa;
+    color: var(--on-surface-variant-color);
     float: right;
     font-size: 28px;
     font-weight: bold;
@@ -478,7 +479,7 @@ input[type="submit"], .btn {
 
 .close:hover,
 .close:focus {
-    color: black;
+    color: var(--on-surface-color);
     text-decoration: none;
     cursor: pointer;
 }

--- a/pickaladder/templates/dashboard.html
+++ b/pickaladder/templates/dashboard.html
@@ -5,9 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard - pickaladder</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='dark.css') }}">
 </head>
-<body class="{{ 'dark-mode' if user and user.dark_mode else '' }}">
+<body>
     {% include 'navbar.html' %}
     <div class="content">
         <div class="container">

--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -7,11 +7,9 @@
     <title>pickaladder - {% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-    {% if user and user.dark_mode %}
     <link rel="stylesheet" href="{{ url_for('static', filename='dark.css') }}">
-    {% endif %}
 </head>
-<body>
+<body class="{{ 'dark-mode' if g.user and g.user.get('dark_mode') else '' }}">
     {% include 'navbar.html' %}
     <div class="container">
         {% with messages = get_flashed_messages(with_categories=true) %}

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -127,11 +127,11 @@ document.addEventListener('DOMContentLoaded', function() {
     function renderUserInfo(user) {
         document.getElementById('user-username').textContent = `@${user.username}`;
         document.getElementById('user-email').textContent = user.email;
-        document.getElementById('user-dupr').textContent = user.duprRating || 'Not set';
+        document.getElementById('user-dupr').textContent = user.dupr_rating || 'Not set';
         document.getElementById('profile-picture-img').src = urls.profile_picture(user.id);
         // Also populate the value in the update form
-        document.getElementById('dupr_rating_input').value = user.duprRating || '';
-        document.querySelector('input[name="dark_mode"]').checked = user.darkMode;
+        document.getElementById('dupr_rating_input').value = user.dupr_rating || '';
+        document.querySelector('input[name="dark_mode"]').checked = user.dark_mode;
     }
 
     function renderTable(tbodyId, items, rowTemplate, noDataMessage) {

--- a/pickaladder/user/routes.py
+++ b/pickaladder/user/routes.py
@@ -109,16 +109,16 @@ def dashboard():
 
     form = UpdateProfileForm()
     if request.method == "GET":
-        form.dupr_rating.data = user_data.get("duprRating")
-        form.dark_mode.data = user_data.get("darkMode")
+        form.dupr_rating.data = user_data.get("dupr_rating")
+        form.dark_mode.data = user_data.get("dark_mode")
 
     if form.validate_on_submit():
         try:
             update_data = {
-                "darkMode": bool(form.dark_mode.data),
+                "dark_mode": bool(form.dark_mode.data),
             }
             if form.dupr_rating.data is not None:
-                update_data["duprRating"] = float(form.dupr_rating.data)
+                update_data["dupr_rating"] = float(form.dupr_rating.data)
 
             profile_picture_file = form.profile_picture.data
             if profile_picture_file:
@@ -504,9 +504,18 @@ def api_dashboard():
             }
         )
 
+    # Prepare user data, ensuring consistent naming
+    user_display_data = {
+        "id": user_id,
+        "username": user_data.get("username"),
+        "email": user_data.get("email"),
+        "dupr_rating": user_data.get("dupr_rating"),
+        "dark_mode": user_data.get("dark_mode", False),
+    }
+
     return jsonify(
         {
-            "user": user_data,
+            "user": user_display_data,
             "friends": friends_data,
             "requests": requests_data,
             "matches": matches_data,


### PR DESCRIPTION
This commit addresses a bug where the dark mode theme was not being applied correctly. The root cause was that the CSS in `dark.css` was not scoped to the `.dark-mode` class, causing the styles to be applied incorrectly.

The following changes have been made:

- The styles in `dark.css` are now wrapped in a `.dark-mode` selector to ensure they are only applied when the dark mode is enabled.
- The `:root` selector in `dark.css` has been changed to `.dark-mode` to correctly scope the CSS variables.
- The conditional loading of the `dark.css` stylesheet has been removed from `layout.html`. The stylesheet is now loaded on every page, and the `dark-mode` class is applied to the `<body>` element based on the user's preference. This simplifies the template and makes the dark mode functionality more reliable.
- The redundant `dark.css` link has been removed from `dashboard.html` to avoid duplicate stylesheets.
- The property name for the dark mode setting has been standardized to `dark_mode` across all templates to ensure consistency with the backend.
- The backend code has been updated to use `dark_mode` and `dupr_rating` instead of `darkMode` and `duprRating` to ensure consistency.
- The CSS in `style.css` has been updated to use CSS variables, allowing the dark mode styles to override them.