### PR TITLE
Fix(lint): Address ruff errors in verify_dark_mode.py

### DIFF
--- a/jules-scratch/verification/verify_dark_mode.py
+++ b/jules-scratch/verification/verify_dark_mode.py
@@ -1,6 +1,10 @@
+"""Verify that dark mode can be enabled."""
+
 from playwright.sync_api import sync_playwright
 
+
 def run(playwright):
+    """Run the playwright test."""
     browser = playwright.chromium.launch(headless=True)
     context = browser.new_context()
     page = context.new_page()
@@ -19,6 +23,7 @@ def run(playwright):
     page.screenshot(path="jules-scratch/verification/dark_mode_verification.png")
 
     browser.close()
+
 
 with sync_playwright() as playwright:
     run(playwright)


### PR DESCRIPTION
This commit fixes the following ruff linting errors in `jules-scratch/verification/verify_dark_mode.py`:
- D100: Missing docstring in public module
- D103: Missing docstring in public function
- I001: Import block is un-sorted or un-formatted