### PR TITLE
fix(lint): Address ruff and mypy errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,3 +29,6 @@ ignore_missing_imports = True
 
 [mypy-imgur_python.*]
 ignore_missing_imports = True
+
+[mypy-playwright.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This commit addresses two sets of static analysis errors:

1.  **Ruff linting errors in `jules-scratch/verification/verify_dark_mode.py`:**
    *   D100: Missing docstring in public module
    *   D103: Missing docstring in public function
    *   I001: Import block is un-sorted or un-formatted

    These were fixed by adding the appropriate docstrings and formatting the file.

2.  **Mypy `import-not-found` error for `playwright.sync_api`:**
    *   This was resolved by adding a rule to `mypy.ini` to ignore missing imports for the `playwright` library, which does not provide type stubs.