### PR TITLE
fix: Resolve test failures caused by incorrect static file endpoint

### DIFF
--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -25,7 +25,12 @@ class UUIDConverter(BaseConverter):
 
 def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
-    app = Flask(__name__, instance_relative_config=True)
+    app = Flask(
+        __name__,
+        instance_relative_config=True,
+        static_folder='static',
+        static_url_path='/static'
+    )
     app.url_map.converters["uuid"] = UUIDConverter
 
     # Load configuration

--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -6,12 +6,12 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>pickaladder - {% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <link rel="icon" href="{{ url_for('user.static', filename='pickaladder_logo_64.png') }}" type="image/png" sizes="64x64">
-    <link rel="icon" href="{{ url_for('user.static', filename='pickaladder_logo_128.png') }}" type="image/png" sizes="128x128">
-    <link rel="icon" href="{{ url_for('user.static', filename='pickaladder_logo_256.png') }}" type="image/png" sizes="256x256">
-    <link rel="icon" href="{{ url_for('user.static', filename='pickaladder_logo_512.png') }}" type="image/png" sizes="512x512">
-    <link rel="stylesheet" href="{{ url_for('user.static', filename='style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('user.static', filename='dark.css') }}">
+    <link rel="icon" href="{{ url_for('static', filename='pickaladder_logo_64.png') }}" type="image/png" sizes="64x64">
+    <link rel="icon" href="{{ url_for('static', filename='pickaladder_logo_128.png') }}" type="image/png" sizes="128x128">
+    <link rel="icon" href="{{ url_for('static', filename='pickaladder_logo_256.png') }}" type="image/png" sizes="256x256">
+    <link rel="icon" href="{{ url_for('static', filename='pickaladder_logo_512.png') }}" type="image/png" sizes="512x512">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='dark.css') }}">
 </head>
 <body class="{{ 'dark-mode' if g.user and g.user.dark_mode else '' }}">
     {% include 'navbar.html' %}

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -2,7 +2,7 @@
     <div class="container">
         <nav class="navbar">
             <a href="{{ url_for('user.dashboard') }}" class="navbar-brand" style="display: flex; align-items: center;">
-                <img src="{{ url_for('user.static', filename='pickaladder_logo_64.png') }}" alt="pickaladder logo" style="height: 24px; margin-right: 8px;">
+                <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" alt="pickaladder logo" style="height: 24px; margin-right: 8px;">
                 pickaladder
             </a>
             <div class="navbar-menu">


### PR DESCRIPTION
Explicitly configures the application's static folder in `pickaladder/__init__.py`. This ensures that the `url_for('static', ...)` endpoint is available in the test environment, resolving the `werkzeug.routing.exceptions.BuildError` that was causing the test suite to fail.

Reverts the `url_for` calls in the `layout.html` and `navbar.html` templates to use the `static` endpoint, which is now correctly configured.