### PR TITLE
fix: Format code with ruff

### DIFF
--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -28,8 +28,8 @@ def create_app(test_config=None):
     app = Flask(
         __name__,
         instance_relative_config=True,
-        static_folder='static',
-        static_url_path='/static'
+        static_folder="static",
+        static_url_path="/static",
     )
     app.url_map.converters["uuid"] = UUIDConverter
 


### PR DESCRIPTION
Runs `ruff format .` to apply the correct formatting to `pickaladder/__init__.py`.