### PR TITLE
This commit fixes a bug on the change password page where a large str…

### DIFF
--- a/pickaladder/templates/change_password.html
+++ b/pickaladder/templates/change_password.html
@@ -4,7 +4,7 @@
 <div class="form-container">
     <h2>Change Password</h2>
     <form method="POST" action="{{ url_for('auth.change_password') }}">
-        {{ csrf_token() }}
+        {{ form.hidden_tag() }}
         <div class="form-group">
             <label for="password">New Password</label>
             <input type="password" name="password" id="password" required>


### PR DESCRIPTION
…ing was being displayed. This was caused by the CSRF token being rendered directly as a string instead of as a hidden input field.

The fix replaces the direct call to `csrf_token()` with `form.hidden_tag()`, which correctly renders the CSRF token as a hidden input field.