### PR TITLE
feat: Fix TypeError on users page

### DIFF
--- a/pickaladder/user/routes.py
+++ b/pickaladder/user/routes.py
@@ -26,6 +26,15 @@ from . import bp
 from .forms import UpdateProfileForm, UpdateUserForm
 
 
+class MockPagination:
+    """A mock pagination object."""
+
+    def __init__(self, items):
+        """Initialize the mock pagination object."""
+        self.items = items
+        self.pages = 1
+
+
 @bp.route("/edit_profile", methods=["GET", "POST"])
 @login_required
 def edit_profile():
@@ -276,10 +285,7 @@ def users():
 
     # The template expects a pagination object with an 'items' attribute.
     # We are not implementing full pagination, just adapting to the template.
-    pagination = {
-        "items": list(user_items),
-        "pages": 1,  # Assume a single page for now
-    }
+    pagination = MockPagination(user_items)
 
     # The template also iterates over 'fof' (friends of friends)
     fof = []


### PR DESCRIPTION
The users page was throwing a TypeError because the template was attempting to iterate over the `.items()` method of a dictionary instead of a list of items.

This commit fixes the issue by introducing a `MockPagination` class that acts as a simple data container. The `users` route now passes an instance of this class to the template, ensuring that `pagination.items` resolves to an iterable list as the template expects.