### PR TITLE
fix: Refactor pagination to prevent template errors

### DIFF
--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -1,5 +1,7 @@
 """Routes for the group blueprint."""
 
+from dataclasses import dataclass
+
 from firebase_admin import firestore
 from flask import flash, g, redirect, render_template, request, url_for
 
@@ -7,6 +9,14 @@ from pickaladder.auth.decorators import login_required
 
 from . import bp
 from .forms import GroupForm, InviteFriendForm
+
+
+@dataclass
+class Pagination:
+    """A simple data class to hold pagination data."""
+
+    items: list
+    pages: int
 
 
 @bp.route("/", methods=["GET"])
@@ -62,14 +72,14 @@ def view_groups():
     enriched_my_groups = [{"group": enrich_group(doc)} for doc in my_group_docs]
 
     # The template expects a pagination object with an 'items' attribute.
-    pagination = {
-        "items": enriched_public_groups,
-        "pages": 1,  # Assume a single page for now
-    }
+    pagination_obj = Pagination(
+        items=enriched_public_groups,
+        pages=1,  # Assume a single page for now
+    )
     return render_template(
         "groups.html",
         my_groups=enriched_my_groups,
-        pagination=pagination,
+        pagination=pagination_obj,
         search_term=search_term,
     )
 


### PR DESCRIPTION
Replaces the dictionary-based pagination object with a dedicated `Pagination` dataclass in the `view_groups` route.

This change prevents a potential `TypeError` in the Jinja2 template where `pagination.items` could be misinterpreted as the `dict.items()` method. Using a dataclass provides a clear and unambiguous attribute, `pagination.items`, ensuring the template can reliably iterate over the list of groups. This makes the solution more robust and prevents a recurrence of the original bug.