### PR TITLE
feat: Remove login flash message

### DIFF
--- a/pickaladder/auth/decorators.py
+++ b/pickaladder/auth/decorators.py
@@ -22,7 +22,6 @@ def login_required(f=None, admin_required=False):
         @wraps(func)
         def decorated_function(*args, **kwargs):
             if "user_id" not in session:
-                flash("Please log in to access this page.", "warning")
                 return redirect(url_for("auth.login"))
             if admin_required and not session.get("is_admin"):
                 flash("You are not authorized to view this page.", "danger")


### PR DESCRIPTION
Removes the "Please log in to access this page." flash message that appears when a user is redirected to the login page.