### PR TITLE
fix: Explicitly pass storage bucket name

### DIFF
--- a/pickaladder/user/routes.py
+++ b/pickaladder/user/routes.py
@@ -133,7 +133,7 @@ def dashboard():
                 filename = secure_filename(
                     profile_picture_file.filename or "profile.jpg"
                 )
-                bucket = storage.bucket()
+                bucket = storage.bucket(os.environ.get("FIREBASE_STORAGE_BUCKET"))
                 blob = bucket.blob(f"profile_pictures/{user_id}/{filename}")
 
                 with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
The application was crashing with a "Storage bucket name not specified" error because the Firebase Admin SDK was not being initialized with the storage bucket name.

This commit fixes the error by explicitly passing the `FIREBASE_STORAGE_BUCKET` environment variable to the `storage.bucket()` function in `pickaladder/user/routes.py`. This ensures that the application can correctly interact with Firebase Storage, even if the storage bucket is not configured during initialization.