### PR TITLE
patch: fix(ci): Correct versioning for release and pre-release builds

### DIFF
--- a/.github/workflows/reusable-versioning.yml
+++ b/.github/workflows/reusable-versioning.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.format-version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -33,7 +33,15 @@ jobs:
           major_pattern: "major:"
           minor_pattern: "minor:"
           namespace: ${{ inputs.namespace }}
-          version_format: "${major}.${minor}.${patch}-${namespace}${increment}"
+
+      - name: Format version string
+        id: format-version
+        run: |
+          if [[ -n "${{ inputs.namespace }}" ]]; then
+            echo "version=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}-${{ inputs.namespace }}.${{ steps.version.outputs.increment }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Configure git
         run: |
@@ -42,5 +50,5 @@ jobs:
 
       - name: Tag new version
         run: |
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
+          git tag ${{ steps.format-version.outputs.version }}
+          git push origin ${{ steps.format-version.outputs.version }}


### PR DESCRIPTION
Refactored the reusable-versioning.yml workflow to correctly generate version numbers for both release and pre-release builds.

The previous implementation used a single `version_format` string that produced an invalid version when no namespace was provided (e.g., on the main branch).

The new implementation separates the version calculation from the final formatting. A new step uses a shell script to conditionally construct the version string:
- For builds without a namespace (e.g., main), it creates a clean release version (e.g., 1.2.3).
- For builds with a namespace (e.g., beta), it creates a valid pre-release version (e.g., 1.2.4-beta.1).

This resolves the issue where the version was appearing incorrectly as `Version: 0.0.1-${namespace}872`.