### PR TITLE
fix(ci): Add 'v' prefix to version tags to trigger release workflow

### DIFF
--- a/.github/workflows/reusable-versioning.yml
+++ b/.github/workflows/reusable-versioning.yml
@@ -38,9 +38,9 @@ jobs:
         id: format-version
         run: |
           if [[ -n "${{ inputs.namespace }}" ]]; then
-            echo "version=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}-${{ inputs.namespace }}.${{ steps.version.outputs.increment }}" >> $GITHUB_OUTPUT
+            echo "version=v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}-${{ inputs.namespace }}.${{ steps.version.outputs.increment }}" >> $GITHUB_OUTPUT
           else
-            echo "version=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}" >> $GITHUB_OUTPUT
+            echo "version=v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Configure git


### PR DESCRIPTION
The release workflow was not being triggered because the version tags generated by the reusable-versioning.yml workflow (e.g., "1.2.3") did not match the expected format with a "v" prefix (e.g., "v1.2.3").

This change adds the "v" prefix to the version string in the reusable-versioning.yml workflow, ensuring that the generated tags will now trigger the release workflow correctly.