### PR TITLE
fix: Correct Firebase Storage bucket initialization

### DIFF
--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -100,10 +100,11 @@ def create_app(test_config=None):
         if cred and not firebase_admin._apps:
             try:
                 storage_bucket = os.environ.get("FIREBASE_STORAGE_BUCKET")
-                if not storage_bucket and project_id:
-                    storage_bucket = f"{project_id}.appspot.com"
-
-                firebase_options = {"storageBucket": storage_bucket}
+                # If the storage bucket is not provided, the SDK will automatically
+                # discover it from the project's service account credentials.
+                firebase_options = {}
+                if storage_bucket:
+                    firebase_options["storageBucket"] = storage_bucket
                 if project_id:
                     firebase_options["projectId"] = project_id
 


### PR DESCRIPTION
The previous implementation incorrectly assumed the Firebase Storage bucket name followed the pattern `{project_id}.appspot.com`. This caused a `404 Not Found` error when the actual bucket name was different.

This commit removes the faulty assumption and relies on the Firebase Admin SDK to automatically discover the correct storage bucket from the provided credentials. This makes the configuration more robust and aligns with the user's setup.