### PR TITLE
fix: Correctly construct Firebase Storage bucket fallback

### DIFF
--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -100,11 +100,10 @@ def create_app(test_config=None):
         if cred and not firebase_admin._apps:
             try:
                 storage_bucket = os.environ.get("FIREBASE_STORAGE_BUCKET")
-                # If the storage bucket is not provided, the SDK will automatically
-                # discover it from the project's service account credentials.
-                firebase_options = {}
-                if storage_bucket:
-                    firebase_options["storageBucket"] = storage_bucket
+                if not storage_bucket and project_id:
+                    storage_bucket = f"{project_id}.firebasestorage.app"
+
+                firebase_options = {"storageBucket": storage_bucket}
                 if project_id:
                     firebase_options["projectId"] = project_id
 


### PR DESCRIPTION
This commit fixes an issue where the Firebase Storage bucket name was not being correctly determined when the `FIREBASE_STORAGE_BUCKET` environment variable was not set.

The previous fix attempted to rely on the Firebase Admin SDK to auto-discover the bucket name, but this proved to be unreliable. This commit reinstates the fallback mechanism, but corrects the bucket name construction to use the `.firebasestorage.app` suffix, as identified from the user's Firebase console.

This ensures that the application can reliably connect to the correct Firebase Storage bucket, even when the environment variable is not explicitly set.