### PR TITLE
feat: Implement a new green-based theme

### DIFF
--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -1,11 +1,14 @@
 /* Dark mode styles */
 body.dark-mode {
-    --background-color: #202124;
-    --surface-color: #303134;
-    --on-primary-color: #e8eaed;
-    --on-surface-color: #e8eaed;
-    --on-surface-variant-color: #969ba1;
-    --border-color: #5f6368;
+    --primary-color: #8ABF83; /* Light Pickle Green */
+    --primary-color-dark: #6E9C69;
+    --secondary-color: #547851;
+    --background-color: #212121; /* Dark Gray */
+    --surface-color: #333333;
+    --on-primary-color: #212121;
+    --on-surface-color: #F5F5F5; /* Off White Text */
+    --on-surface-variant-color: #BDBDBD;
+    --border-color: #616161;
 }
 
 body.dark-mode input[type="text"],
@@ -26,7 +29,7 @@ body.dark-mode input[type="number"]:focus,
 body.dark-mode input[type="date"]:focus,
 body.dark-mode select:focus {
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(66, 133, 244, 0.3);
+    box-shadow: 0 0 0 2px rgba(138, 191, 131, 0.3);
 }
 
 body.dark-mode .table th {

--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -1,16 +1,16 @@
 /* Basic styling */
 :root {
-    --primary-color: #4285F4; /* Google Blue */
-    --primary-color-dark: #3367D6;
-    --secondary-color: #34A853; /* Google Green */
+    --primary-color: #5A8C55; /* Darker Pickle Green */
+    --primary-color-dark: #456B42;
+    --secondary-color: #8ABF83; /* Light Pickle Green */
     --danger-color: #EA4335; /* Google Red */
     --warning-color: #FBBC05; /* Google Yellow */
-    --background-color: #f8f9fa;
+    --background-color: #F5F5F5; /* Off White */
     --surface-color: #ffffff;
     --on-primary-color: #ffffff;
-    --on-surface-color: #202124;
-    --on-surface-variant-color: #5f6368;
-    --border-color: #dadce0;
+    --on-surface-color: #212121; /* Dark Text */
+    --on-surface-variant-color: #616161;
+    --border-color: #E0E0E0;
     --font-family: 'Roboto', sans-serif;
     --box-shadow: 0 1px 2px 0 rgba(60,64,67,0.302), 0 1px 3px 1px rgba(60,64,67,0.149);
     --border-radius: 8px;
@@ -172,7 +172,7 @@ input[type="date"]:focus,
 select:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(66, 133, 244, 0.2);
+    box-shadow: 0 0 0 2px rgba(90, 140, 85, 0.2);
 }
 
 input,


### PR DESCRIPTION
This commit introduces a new, modern color scheme for the application, inspired by the app's icon. The new theme is applied to both the light and dark modes, and the primary color has been adjusted to meet accessibility standards.

- A new color palette has been defined in `style.css` and `dark.css` using CSS variables.
- The light theme now uses a fresh, green-based color scheme.
- The dark theme has been updated to complement the new light theme.
- The primary color in the light theme has been adjusted to ensure a sufficient contrast ratio with white text.