### PR TITLE
fix: Improve button contrast in dark mode

### DIFF
--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -65,6 +65,10 @@ body.dark-mode a {
     color: #8ab4f8; /* A light, high-contrast blue */
 }
 
+body.dark-mode .btn {
+    color: var(--on-primary-color);
+}
+
 body.dark-mode .dropbtn {
     background-color: var(--surface-color);
 }


### PR DESCRIPTION
This commit fixes a contrast issue with buttons in dark mode. The previous implementation had a general rule for links that was overriding the button text color, resulting in low-contrast and unreadable text.

- A new CSS rule has been added to `dark.css` to specifically target buttons, ensuring they have a high-contrast text color that is consistent with the dark theme.