### PR TITLE
feat: Apply the new theme to the header

### DIFF
--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -76,3 +76,13 @@ body.dark-mode .dropbtn {
 body.dark-mode .hamburger-menu {
     background-color: transparent;
 }
+
+body.dark-mode .header {
+    background-color: var(--primary-color-dark);
+    border-bottom: 1px solid var(--primary-color);
+}
+
+body.dark-mode .navbar-brand,
+body.dark-mode .navbar-menu a {
+    color: var(--on-surface-color);
+}

--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -62,8 +62,8 @@ body {
 
 /* Header and Navbar */
 .header {
-    background-color: var(--surface-color);
-    border-bottom: 1px solid var(--border-color);
+    background-color: var(--primary-color);
+    border-bottom: 1px solid var(--primary-color-dark);
     padding: 10px 0;
     margin-bottom: 20px;
 }
@@ -77,7 +77,7 @@ body {
 .navbar-brand {
     font-size: 1.5em;
     font-weight: 500;
-    color: var(--on-surface-color);
+    color: var(--on-primary-color);
     text-decoration: none;
 }
 
@@ -89,7 +89,7 @@ body {
 
 .navbar-menu a {
     text-decoration: none;
-    color: var(--on-surface-color);
+    color: var(--on-primary-color);
 }
 
 


### PR DESCRIPTION
This commit applies the new green-based theme to the header and navigation bar, ensuring a consistent and modern look across the entire application.

- The header background and text colors have been updated in both light and dark modes to match the new theme.
- The changes have been applied to `style.css` and `dark.css` to ensure a cohesive look in both themes.