### PR TITLE
feat: Add Nginx reverse proxy for HTTP/HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ cookies2.txt
 url_map.txt
 .env
 firebase_credentials.json
+
+# SSL certificates
+nginx/ssl/self-signed.crt
+nginx/ssl/self-signed.key

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,8 +2,6 @@ services:
   web:
     image: ${IMAGE_TAG}
     restart: always
-    ports:
-      - "27272:27272"
     command: gunicorn --bind 0.0.0.0:27272 --timeout 120 app:app
     environment:
       # These variables should be set in the production environment (e.g., GitHub Secrets)
@@ -21,6 +19,21 @@ services:
       - APP_VERSION=${APP_VERSION}
     networks:
       - pickanet
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile.prod
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot
+    networks:
+      - pickanet
+    depends_on:
+      - web
 
 networks:
   pickanet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,17 @@
 services:
   web:
     build: .
-    ports:
-      - "27272:27272"
     volumes:
       - .:/app
     command: gunicorn --bind 0.0.0.0:27272 --timeout 120 app:app
     env_file:
       - .env
+  nginx:
+    build: ./nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/ssl:/etc/nginx/ssl
+    depends_on:
+      - web

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx/Dockerfile.prod
+++ b/nginx/Dockerfile.prod
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY nginx.prod.conf /etc/nginx/nginx.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,37 @@
+user nginx;
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream web {
+        server web:27272;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate /etc/nginx/ssl/self-signed.crt;
+        ssl_certificate_key /etc/nginx/ssl/self-signed.key;
+
+        location / {
+            proxy_pass http://web;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -1,0 +1,41 @@
+user nginx;
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream web {
+        server web:27272;
+    }
+
+    server {
+        listen 80;
+        server_name your_domain.com www.your_domain.com;
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name your_domain.com www.your_domain.com;
+
+        ssl_certificate /etc/letsencrypt/live/your_domain.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/your_domain.com/privkey.pem;
+
+        location / {
+            proxy_pass http://web;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces an Nginx reverse proxy to handle incoming HTTP and HTTPS traffic.

- Adds an Nginx service to the Docker Compose setup for both local development and production.
- Configures Nginx to listen on ports 80 and 443, with HTTP traffic being redirected to HTTPS.
- For local development, self-signed SSL certificates are used.
- The production configuration is set up to work with Let's Encrypt.
- The `web` service no longer exposes port 27272 directly.
- The self-signed SSL certificate and key are added to `.gitignore` to prevent them from being committed to the repository.