### PR TITLE
feat: Add certbot for automated SSL renewal

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,6 +34,15 @@ services:
       - pickanet
     depends_on:
       - web
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    networks:
+      - pickanet
 
 networks:
   pickanet:

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -12,7 +12,7 @@ http {
 
     server {
         listen 80;
-        server_name your_domain.com www.your_domain.com;
+        server_name pickaladder.io www.pickaladder.io;
 
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
@@ -25,10 +25,10 @@ http {
 
     server {
         listen 443 ssl;
-        server_name your_domain.com www.your_domain.com;
+        server_name pickaladder.io www.pickaladder.io;
 
-        ssl_certificate /etc/letsencrypt/live/your_domain.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/your_domain.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/pickaladder.io/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/pickaladder.io/privkey.pem;
 
         location / {
             proxy_pass http://web;


### PR DESCRIPTION
This commit adds a `certbot` service to the production Docker Compose setup to automate the process of obtaining and renewing Let's Encrypt SSL certificates.

- The `docker-compose.prod.yml` file is updated with a new `certbot` service that shares the necessary volumes with the Nginx container.
- The production Nginx configuration (`nginx.prod.conf`) has been updated to use the domain `pickaladder.io`.