### PR TITLE
feat: Automate initial SSL certificate generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,14 +49,14 @@ jobs:
           script: |
             mkdir -p ~/picka-server
 
-      - name: Copy config files to server
+      - name: Copy config and deployment script to server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.HOSTINGER_HOST }}
           username: ${{ secrets.HOSTINGER_USERNAME }}
           key: ${{ secrets.HOSTINGER_SSH_KEY }}
           port: 22
-          source: "docker-compose.prod.yml,nginx"
+          source: "docker-compose.prod.yml,nginx,init-letsencrypt.sh"
           target: "~/picka-server"
 
       - name: Deploy to Hostinger VPS
@@ -68,19 +68,12 @@ jobs:
           port: 22
           script: |
             cd ~/picka-server
-
-            # NOTE: Before the first deployment, you must manually run the certbot
-            # command to generate the initial SSL certificates. Your domain's DNS
-            # must be pointing to this server's IP address.
-            #
-            # sudo docker-compose -f docker-compose.prod.yml run --rm certbot certonly --webroot \
-            #   --webroot-path /var/www/certbot --email YOUR_EMAIL@EXAMPLE.COM --agree-tos --no-eff-email \
-            #   -d pickaladder.io -d www.pickaladder.io
+            chmod +x init-letsencrypt.sh
 
             # Login to GitHub Container Registry
             docker login ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
 
-            # Set environment variables for docker-compose
+            # Set environment variables for docker-compose and the deployment script
             export IMAGE_TAG=ghcr.io/${{ github.repository }}:${{ github.sha }}
             export SECRET_KEY='${{ secrets.SECRET_KEY }}'
             export MAIL_SERVER='${{ secrets.MAIL_SERVER }}'
@@ -95,12 +88,8 @@ jobs:
             export IMGUR_CLIENT_ID='${{ secrets.IMGUR_CLIENT_ID }}'
             export APP_VERSION='${{ github.ref_name }}'
 
-            # Stop existing services before starting new ones.
-            # Using older docker-compose command based on user feedback.
-            docker-compose -f docker-compose.prod.yml down
-
-            # Recreate the services, building the nginx image and pulling the web image
-            docker-compose -f docker-compose.prod.yml up --build -d
+            # Execute the deployment script
+            ./init-letsencrypt.sh
 
             # Clean up old images
             # This helps to free up disk space on the server.

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# This script is designed to be run by the CI/CD pipeline on the production server.
+# It handles the initial Let's Encrypt certificate generation automatically.
+
+DOMAIN="pickaladder.io"
+EMAIL="pickaladder@gmail.com"
+CERT_DIR="/etc/letsencrypt/live/$DOMAIN"
+
+echo ">>> Checking for existing certificate at $CERT_DIR..."
+
+# The main deployment logic is wrapped in this if/else block.
+# If a certificate already exists, we just start the services.
+# If not, we run the one-time generation process.
+if [ -d "$CERT_DIR" ]; then
+    echo "Certificate found. Starting services..."
+else
+    echo "Certificate not found. Starting first-time generation process..."
+
+    # 1. Create dummy certificate files so Nginx can start
+    echo ">>> Creating dummy certificate..."
+    sudo mkdir -p $CERT_DIR
+    sudo openssl req -x509 -nodes -newkey rsa:4096 -days 1 \
+        -keyout "$CERT_DIR/privkey.pem" \
+        -out "$CERT_DIR/fullchain.pem" \
+        -subj "/CN=localhost"
+
+    # 2. Start only Nginx. It needs to be running to solve the
+    # HTTP-01 challenge from Let's Encrypt.
+    echo ">>> Starting Nginx with dummy certificate..."
+    docker-compose -f docker-compose.prod.yml up -d nginx
+
+    # 3. Replace the dummy certificate with a real one from Let's Encrypt.
+    # We remove the dummy files before certbot runs.
+    echo ">>> Requesting real certificate from Let's Encrypt..."
+    sudo rm -rf $CERT_DIR
+    docker-compose -f docker-compose.prod.yml run --rm certbot certonly --webroot \
+        --webroot-path /var/www/certbot \
+        --email $EMAIL \
+        --agree-tos \
+        --no-eff-email \
+        --force-renewal \
+        -d $DOMAIN -d www.$DOMAIN
+
+    # 4. Stop the Nginx container that was using the dummy cert.
+    # The next step will bring everything up with the real cert.
+    echo ">>> Shutting down Nginx..."
+    docker-compose -f docker-compose.prod.yml down
+fi
+
+# 5. Start or restart all services with the final configuration and real certificate.
+echo ">>> Starting all services for production..."
+docker-compose -f docker-compose.prod.yml up --build -d
+
+echo ">>> Deployment script finished successfully."


### PR DESCRIPTION
This commit introduces a script to fully automate the initial Let's Encrypt SSL certificate generation, enabling a zero-touch deployment process.

- Adds a new `init-letsencrypt.sh` script that handles the bootstrapping of SSL certificates. It starts Nginx with a temporary dummy certificate, requests a real one from Let's Encrypt using the `certbot` service, and then restarts the full application stack.
- The user's email, `pickaladder@gmail.com`, is used for the Let's Encrypt registration within the script.
- The `release.yml` workflow is updated to copy and execute this new script on the server, replacing the previous manual deployment steps.