### PR TITLE
fix: Add robust polling to deployment script

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -32,16 +32,20 @@ else
     echo ">>> Starting web and nginx with dummy certificate..."
     docker-compose -f docker-compose.prod.yml up -d web nginx
 
-    # 3. Wait for the 'web' service to be discoverable by Nginx.
+    # 3. Give the Docker network a moment to initialize before we start polling.
+    echo ">>> Waiting for network to settle..."
+    sleep 5
+
+    # 4. Wait for the 'web' service to be discoverable by Nginx via DNS.
     # This loop runs inside the nginx container and polls for the 'web' hostname.
     echo ">>> Waiting for web service to be ready..."
-    until docker-compose -f docker-compose.prod.yml exec nginx sh -c 'getent hosts web'; do
+    until docker-compose -f docker-compose.prod.yml exec nginx sh -c 'nslookup web'; do
         echo "Still waiting for web service..."
         sleep 3
     done
     echo "Web service is ready."
 
-    # 4. Replace the dummy certificate with a real one from Let's Encrypt.
+    # 5. Replace the dummy certificate with a real one from Let's Encrypt.
     # We remove the dummy files before certbot runs.
     echo ">>> Requesting real certificate from Let's Encrypt..."
     sudo rm -rf $CERT_DIR


### PR DESCRIPTION
This commit fixes a persistent race condition in the `init-letsencrypt.sh` script where the Nginx container would fail before the `web` container was available on the network.

- Adds a 5-second initial delay to allow the Docker network to stabilize.
- Replaces the previous `getent hosts` check with a more robust `nslookup` polling loop. This ensures the script only proceeds after the `web` service is fully discoverable via DNS within the Docker network.

This change makes the automated deployment process significantly more resilient and should permanently resolve the "host not found in upstream" error during initial setup.