### PR TITLE
fix: Add Nginx entrypoint to solve race condition

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -26,26 +26,12 @@ else
         -out "$CERT_DIR/fullchain.pem" \
         -subj "/CN=localhost"
 
-    # 2. Start the web and nginx services. Nginx needs the web service to be
-    # running to resolve the upstream, and it needs to be running itself
-    # to solve the HTTP-01 challenge from Let's Encrypt.
+    # 2. Start the web and nginx services. The new Nginx entrypoint will
+    # automatically wait for the web service to be ready.
     echo ">>> Starting web and nginx with dummy certificate..."
     docker-compose -f docker-compose.prod.yml up -d web nginx
 
-    # 3. Give the Docker network a moment to initialize before we start polling.
-    echo ">>> Waiting for network to settle..."
-    sleep 5
-
-    # 4. Wait for the 'web' service to be discoverable by Nginx via DNS.
-    # This loop runs inside the nginx container and polls for the 'web' hostname.
-    echo ">>> Waiting for web service to be ready..."
-    until docker-compose -f docker-compose.prod.yml exec nginx sh -c 'nslookup web'; do
-        echo "Still waiting for web service..."
-        sleep 3
-    done
-    echo "Web service is ready."
-
-    # 5. Replace the dummy certificate with a real one from Let's Encrypt.
+    # 3. Replace the dummy certificate with a real one from Let's Encrypt.
     # We remove the dummy files before certbot runs.
     echo ">>> Requesting real certificate from Let's Encrypt..."
     sudo rm -rf $CERT_DIR

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,7 @@
 FROM nginx:alpine
+
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/nginx/Dockerfile.prod
+++ b/nginx/Dockerfile.prod
@@ -1,2 +1,7 @@
 FROM nginx:alpine
+
 COPY nginx.prod.conf /etc/nginx/nginx.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# This script is the entrypoint for the Nginx container.
+# It waits until the 'web' service is reachable before starting Nginx.
+
+UPSTREAM_HOST="web"
+UPSTREAM_PORT="27272"
+
+echo ">>> Nginx Entrypoint: Waiting for upstream host $UPSTREAM_HOST..."
+
+# Use a loop to check if the upstream host is resolvable.
+# 'getent hosts' is a standard way to check for hostname resolution.
+until getent hosts $UPSTREAM_HOST; do
+    echo "Still waiting for upstream host $UPSTREAM_HOST..."
+    sleep 2
+done
+
+echo ">>> Nginx Entrypoint: Upstream host found. Starting Nginx..."
+
+# Execute the original Nginx entrypoint script.
+# This will start the Nginx process.
+exec /docker-entrypoint.sh nginx -g 'daemon off;'


### PR DESCRIPTION
This commit introduces a definitive fix for the persistent "host not found in upstream" race condition that occurred during deployment.

The root cause was the Nginx container starting before the `web` container was available on the network. This is now solved by moving the waiting logic inside the Nginx container itself.

- Adds a new `nginx/entrypoint.sh` script that runs on container startup. This script waits until it can successfully resolve the `web` hostname before launching the main Nginx process.
- Updates `nginx/Dockerfile` and `nginx/Dockerfile.prod` to use this new entrypoint, making the container self-sufficient and aware of its dependency.
- Simplifies the main `init-letsencrypt.sh` deployment script by removing the now-redundant and fragile external polling logic.

This change makes the multi-container startup sequence significantly more robust and reliable, permanently resolving the deployment failures.