### PR TITLE
fix: remove explicit ipv6 bindings and robustify deployment script

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,9 +33,7 @@ services:
     restart: always
     ports:
       - "80:80"
-      - "[::]:80:80"
       - "443:443"
-      - "[::]:443:443"
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot


### PR DESCRIPTION
The deployment was failing with "Address already in use" on `[::]:80` despite `lsof` showing no listeners. This is likely due to an IPv6 configuration issue on the host or Docker daemon.

This commit:
1.  Removes explicit IPv6 port bindings (`[::]:80:80`, `[::]:443:443`) from `docker-compose.prod.yml`, relying on Docker's default binding behavior (which typically binds `0.0.0.0` or both if correctly configured), thus avoiding the explicit bind failure.
2.  Updates `init-letsencrypt.sh` to use `lsof -sTCP:LISTEN` to correctly ignore outbound connections (like system agents) that were causing false positive conflict detections.
3.  Adds robustness (`|| true`) and diagnostic logging to `init-letsencrypt.sh` to prevent crashes and assist debugging if bindings fail again.