### PR TITLE
feat: include invited users in match creation (fix field name)

### DIFF
--- a/pickaladder/match/routes.py
+++ b/pickaladder/match/routes.py
@@ -216,7 +216,7 @@ def create_match():
     # 3. Users invited to any group by the current user
     my_invites_query = (
         db.collection("group_invites")
-        .where(filter=firestore.FieldFilter("invited_by", "==", user_id))
+        .where(filter=firestore.FieldFilter("inviter_id", "==", user_id))
         .where(filter=firestore.FieldFilter("used", "==", False))
         .stream()
     )


### PR DESCRIPTION
Fixed a bug where the match creation form failed to include users who had been invited to a group but hadn't joined yet.
- Corrected the Firestore field name for querying invites from `invited_by` to `inviter_id` in `pickaladder/match/routes.py`.
- Ensured that users invited by the current user are correctly fetched and displayed in the opponent dropdown.
- Maintained the batch size limit of 10 for user lookups to respect Firestore `in` query constraints.