### PR TITLE
Refactor CI/CD versioning to use git tags instead of commits

### DIFF
--- a/.github/workflows/reusable-versioning.yml
+++ b/.github/workflows/reusable-versioning.yml
@@ -40,12 +40,7 @@ jobs:
           git config --global user.name "picka-bot"
           git config --global user.email "picka-bot@users.noreply.github.com"
 
-      - name: Update version file
+      - name: Create and push tag
         run: |
-          echo ${{ steps.version.outputs.version }} > VERSION
-
-      - name: Commit new version
-        run: |
-          git add VERSION
-          git commit -m "chore(version): update to ${{ steps.version.outputs.version }} [skip ci]"
-          git push origin HEAD:${{ github.ref_name }}
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Refactored the CI/CD versioning process to create and push a git tag with the new version, instead of committing a VERSION file. This avoids creating unnecessary commits for version changes.

## 🛠 Integration Contribution Summary
### 🎯 Versioning & Type
**PR Title Format:** `[major|minor|patch] Short Description`
- [ ] **Type:** (Bug fix / New feature / Breaking change)

### 🔗 Context
- **Linked Issue:** Fixes #
- **Milestone:** 

### ✍️ Documentation & Quality
- [ ] **Comments:** I have commented code in complex logic areas.
- [ ] **Self-Review:** I have verified this code generates no new warnings.
- [ ] **Roadmap:** I have marked the task as complete in `ROADMAP.md` (if applicable).

---
**Contributor Type:**
- [ ] Human Developer
- [ ] Jules AI Agent

