### PR TITLE
Add service account key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ firebase_credentials.json
 # SSL certificates
 nginx/ssl/self-signed.crt
 nginx/ssl/self-signed.key
+serviceAccountKey.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     build: .
     volumes:
       - .:/app
+      - ./serviceAccountKey.json:/app/serviceAccountKey.json
     command: gunicorn --bind 0.0.0.0:27272 --workers 2 --threads 4 --worker-class gthread --timeout 120 app:app
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/serviceAccountKey.json
     env_file:
       - .env
     networks:


### PR DESCRIPTION
This change adds the service account key to the `docker-compose.yml` file and also adds the service account key to the `.gitignore` file.

Fixes #447

---
*PR created automatically by Jules for task [9022665733890281012](https://jules.google.com/task/9022665733890281012) started by @brewmarsh*