### PR TITLE
Fix Application Credentials Configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     volumes:
       - .:/app
-      - ./serviceAccountKey.json:/app/serviceAccountKey.json
+      - ./serviceAccountKey.json:/app/serviceAccountKey.json:ro
     command: gunicorn --bind 0.0.0.0:27272 --workers 2 --threads 4 --worker-class gthread --timeout 120 app:app
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/app/serviceAccountKey.json


### PR DESCRIPTION
This change updates the docker-compose.yml file to make the serviceAccountKey.json volume read-only, which is a security best practice. It also verifies that the key is in .gitignore to prevent it from being committed to the repository.

Fixes #449

---
*PR created automatically by Jules for task [123821866300929423](https://jules.google.com/task/123821866300929423) started by @brewmarsh*