### PR TITLE
Fix: Make datetime comparison timezone-aware

### DIFF
--- a/pickaladder/group/utils.py
+++ b/pickaladder/group/utils.py
@@ -2,7 +2,7 @@
 
 import secrets
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from firebase_admin import firestore
 
@@ -177,7 +177,7 @@ def get_group_leaderboard(group_id):
     current_leaderboard = _calculate_leaderboard_from_matches(member_refs, all_matches)
 
     # Calculate leaderboard from a week ago for rank trend
-    one_week_ago = datetime.now() - timedelta(days=7)
+    one_week_ago = datetime.now(timezone.utc) - timedelta(days=7)
     matches_last_week = [
         m
         for m in all_matches


### PR DESCRIPTION
This change addresses a TypeError in 'pickaladder/group/utils.py' by making the datetime comparison in 'get_group_leaderboard' timezone-aware. This prevents a 500 error on the dashboard.

Fixes #467

---
*PR created automatically by Jules for task [15803350384985732916](https://jules.google.com/task/15803350384985732916) started by @brewmarsh*