### PR TITLE
Restore Pending Member Visibility

### DIFF
--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -71,6 +71,7 @@
             <table class="table responsive-table">
                 <thead>
                     <tr>
+                        <th style="width: 50px;"></th>
                         <th>Name</th>
                         <th>Email</th>
                         <th>Status</th>
@@ -80,7 +81,11 @@
                 <tbody>
                     {% for invite in pending_invites %}
                     <tr>
-                        <td data-label="Name">{{ invite.name }}</td>
+                        <td data-label="Avatar">
+                            <img src="{{ invite.profilePictureUrl or url_for('static', filename='user_icon.png') }}"
+                                 alt="Profile Picture" class="profile-picture-thumbnail">
+                        </td>
+                        <td data-label="Name">{{ invite.username or invite.name }}</td>
                         <td data-label="Email">{{ invite.email }}</td>
                         <td data-label="Status">
                             {% if invite.status == 'failed' %}


### PR DESCRIPTION
This change restores the visibility of pending members in the group dashboard. The backend is updated to fetch pending member details, and the frontend is updated to display this information. The implementation also includes a fix to handle Firestore's query limitations, ensuring the application remains stable even with a large number of pending invitations.

Fixes #469

---
*PR created automatically by Jules for task [1386631041664815284](https://jules.google.com/task/1386631041664815284) started by @brewmarsh*