### PR TITLE
Fix player1 naming mismatch in match recording

### DIFF
--- a/pickaladder/match/routes.py
+++ b/pickaladder/match/routes.py
@@ -299,7 +299,7 @@ def record_match():
             )
 
         # Populate choices for validation to work
-        form.player_1.choices = [(p_id, "") for p_id in candidate_player_ids]
+        form.player1.choices = [(p_id, "") for p_id in candidate_player_ids]
         form.player2.choices = [(p_id, "") for p_id in candidate_player_ids]
         if data.get("match_type") == "doubles":
             form.partner.choices = form.player2.choices
@@ -358,7 +358,7 @@ def record_match():
                     (user_doc.id, user_doc.to_dict().get("name", user_doc.id))
                 )
 
-    form.player_1.choices = player_choices
+    form.player1.choices = player_choices
     form.player2.choices = player_choices
     form.partner.choices = player_choices
     form.opponent2.choices = player_choices
@@ -373,7 +373,7 @@ def record_match():
                 form.match_type.data = last_match_type
 
     if form.validate_on_submit():
-        player_1_id = request.form.get("player_1") or user_id
+        player_1_id = request.form.get("player1") or user_id
 
         # Uniqueness check
         player_ids = [player_1_id, form.player2.data]

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -110,11 +110,16 @@ class MatchRoutesFirebaseTestCase(unittest.TestCase):
         mock_db = self.mock_firestore_service.client.return_value
 
         # Mock the db.get_all call that populates the form choices
+        mock_user_snapshot = MagicMock()
+        mock_user_snapshot.exists = True
+        mock_user_snapshot.id = MOCK_USER_ID
+        mock_user_snapshot.to_dict.return_value = MOCK_USER_DATA
+
         mock_opponent_snapshot = MagicMock()
         mock_opponent_snapshot.exists = True
         mock_opponent_snapshot.id = MOCK_OPPONENT_ID
         mock_opponent_snapshot.to_dict.return_value = MOCK_OPPONENT_DATA
-        mock_db.get_all.return_value = [mock_opponent_snapshot]
+        mock_db.get_all.return_value = [mock_user_snapshot, mock_opponent_snapshot]
 
         mock_matches_collection = mock_db.collection("matches")
 
@@ -122,6 +127,7 @@ class MatchRoutesFirebaseTestCase(unittest.TestCase):
             "/match/record",
             headers=self._get_auth_headers(),
             data={
+                "player1": MOCK_USER_ID,
                 "player2": MOCK_OPPONENT_ID,
                 "player1_score": 11,
                 "player2_score": 5,


### PR DESCRIPTION
This change corrects a naming inconsistency for the 'player1' form field. It updates all references from 'player_1' to 'player1' in pickaladder/match/routes.py and tests/test_match.py to prevent an AttributeError and fix the match recording functionality.

Fixes #478

---
*PR created automatically by Jules for task [1022798488264792384](https://jules.google.com/task/1022798488264792384) started by @brewmarsh*