### PR TITLE
Add Winning Streak Feature to Group Leaderboard

### DIFF
--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -204,7 +204,12 @@
                     <div class="leaderboard-cell" data-label="Player">
                         <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link">
                             <img src="{{ player.profilePictureUrl or url_for('static', filename='user_icon.png') }}" alt="{{ player.name }}" class="profile-picture-thumbnail">
-                            <span class="player-name">{{ player.name }}</span>
+                            <span class="player-name">
+                                {{ player.name }}
+                                {% if player.is_on_fire %}
+                                    <span title="{{ player.streak }} Game Streak!">🔥</span>
+                                {% endif %}
+                            </span>
                         </a>
                     </div>
                     <div class="leaderboard-cell" data-label="Avg. Score">{{ "%.2f"|format(player.avg_score|float) }}</div>


### PR DESCRIPTION
This change introduces a "Winning Streak" feature to the Group Leaderboard. It calculates each player's current winning streak and displays a fire emoji with a tooltip for streaks of three or more, making the leaderboard more engaging. The backend logic is updated in `pickaladder/group/utils.py` and the frontend in `pickaladder/templates/group.html`.

Fixes #499

---
*PR created automatically by Jules for task [9047714117770603780](https://jules.google.com/task/9047714117770603780) started by @brewmarsh*