### PR TITLE
Add Giant Slayer Upset Victory Feature

### DIFF
--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -380,6 +380,27 @@ def view_group(group_id):
             get_id(match_data, ["opponent2", "opponent2Id", "opponent2_id"]),
             {"username": "Unknown"},
         )
+
+        # --- Giant Slayer Logic ---
+        winner_player = None
+        loser_player = None
+        # This logic primarily considers singles matches for now.
+        if match_data.get("winner") == "team1":
+            winner_player = match_data.get("player1")
+            loser_player = match_data.get("player2")
+        elif match_data.get("winner") == "team2":
+            winner_player = match_data.get("player2")
+            loser_player = match_data.get("player1")
+
+        if winner_player and loser_player:
+            # Ensure ratings are treated as floats, defaulting to 0.0
+            winner_rating = float(winner_player.get("dupr_rating") or 0.0)
+            loser_rating = float(loser_player.get("dupr_rating") or 0.0)
+
+            if loser_rating > 0 and winner_rating > 0:  # Both must have a rating
+                if (loser_rating - winner_rating) >= 0.25:
+                    match_data["is_upset"] = True
+
         recent_matches.append(match_data)
 
     return render_template(

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -251,9 +251,26 @@
                     {% for match in recent_matches %}
                     <tr>
                         <td data-label="Date">{{ match.matchDate.strftime('%Y-%m-%d') if match.matchDate else 'N/A' }}</td>
-                        <td data-label="Player 1">{{ match.player1.username }}</td>
-                        <td data-label="Player 2">{{ match.player2.username }}</td>
-                        <td data-label="Score">{{ match.player1Score }} - {{ match.player2Score }}</td>
+                        {% if match.winner == 'team1' %}
+                            <td data-label="Player 1">
+                                {{ match.player1.username }}
+                                {% if match.is_upset %}
+                                <span title="Giant Slayer! Beat a higher-ranked opponent.">🗡️</span>
+                                {% endif %}
+                            </td>
+                            <td data-label="Player 2">{{ match.player2.username }}</td>
+                        {% else %}
+                            <td data-label="Player 1">{{ match.player1.username }}</td>
+                            <td data-label="Player 2">
+                                {{ match.player2.username }}
+                                {% if match.is_upset %}
+                                <span title="Giant Slayer! Beat a higher-ranked opponent.">🗡️</span>
+                                {% endif %}
+                            </td>
+                        {% endif %}
+                        <td data-label="Score" {% if match.is_upset %}style="font-weight: bold; color: green;"{% endif %}>
+                            {{ match.player1Score }} - {{ match.player2Score }}
+                        </td>
                     </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
This feature adds a "Giant Slayer" award to the recent matches list, highlighting upset victories. It updates the backend to identify these matches based on DUPR ratings and modifies the frontend to display a special icon and styling for these victories.

Fixes #500

---
*PR created automatically by Jules for task [2332998307617590615](https://jules.google.com/task/2332998307617590615) started by @brewmarsh*