### PR TITLE
Redesign Rivalry Check card with Versus layout

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -950,3 +950,18 @@ input[type="submit"], .btn {
         grid-template-columns: repeat(2, 1fr);
     }
 }
+
+.rivalry-check-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+.rivalry-player-select {
+    width: 45%;
+}
+.rivalry-vs {
+    font-weight: bold;
+    font-size: 1.2em;
+}

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -147,23 +147,26 @@
 
     <div class="card">
         <h3>Rivalry Check</h3>
-        <div class="form-group">
-            <label for="player1-select">Player 1</label>
-            <select id="player1-select" class="form-control">
-                <option value="">Select a player</option>
-                {% for member in members %}
-                    <option value="{{ member.id }}">{{ member.username }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="form-group">
-            <label for="player2-select">Player 2</label>
-            <select id="player2-select" class="form-control">
-                <option value="">Select a player</option>
-                {% for member in members %}
-                    <option value="{{ member.id }}">{{ member.username }}</option>
-                {% endfor %}
-            </select>
+        <div class="rivalry-check-container">
+            <div class="rivalry-player-select">
+                <label for="player1-select">Player 1</label>
+                <select id="player1-select" class="form-control">
+                    <option value="">Select a player</option>
+                    {% for member in members %}
+                        <option value="{{ member.id }}">{{ member.username }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="rivalry-vs">VS</div>
+            <div class="rivalry-player-select">
+                <label for="player2-select">Player 2</label>
+                <select id="player2-select" class="form-control">
+                    <option value="">Select a player</option>
+                    {% for member in members %}
+                        <option value="{{ member.id }}">{{ member.username }}</option>
+                    {% endfor %}
+                </select>
+            </div>
         </div>
         <div id="head-to-head-stats" style="margin-top: 15px;">
             <!-- Stats will be loaded here -->


### PR DESCRIPTION
This change redesigns the "Rivalry Check" card on the group page to use a more compact and visual "Versus" layout. The two player dropdowns are now positioned side-by-side with a bold "VS" in the middle, and the existing AJAX functionality for fetching and displaying head-to-head stats is preserved.

Fixes #506

---
*PR created automatically by Jules for task [9810616588265947238](https://jules.google.com/task/9810616588265947238) started by @brewmarsh*