### PR TITLE
Fix Group Page Template Structure

### DIFF
--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block title %}{{ group.name }}{% endblock %}
+{% block content %}
 <div class="page-header group-header-content">
     <img src="{{ group.profilePictureUrl if group.profilePictureUrl else (url_for('static', filename='uploads/' + group.profile_picture_path) if group.profile_picture_path else url_for('static', filename='user_icon.png')) }}" alt="Group Picture" class="group-profile-picture">
     <div>


### PR DESCRIPTION
This change fixes a Jinja2 template syntax error in `pickaladder/templates/group.html` by adding the missing `{% block content %}` tag. This resolves the `Encountered unknown tag 'endblock'` error and ensures the group page renders correctly within the application's layout.

Fixes #513

---
*PR created automatically by Jules for task [5025249964488680969](https://jules.google.com/task/5025249964488680969) started by @brewmarsh*