### PR TITLE
Improve Leaderboard Contrast

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -839,7 +839,12 @@ input[type="submit"], .btn {
 
 .highlight-user {
     border-left: 4px solid var(--primary-color);
-    background-color: #E8F5E9; /* A light green */
+    background-color: #2e7d32;
+}
+
+/* Ensure all text and links within the highlighted row are white for contrast */
+.highlight-user, .highlight-user .player-link {
+    color: #ffffff;
 }
 
 /* Latest Games Section */


### PR DESCRIPTION
This change updates the CSS for the highlighted user row in the Group Leaderboard to improve readability by changing the background color to a darker green and setting the text color to white for better contrast.

Fixes #517

---
*PR created automatically by Jules for task [1620087171184734180](https://jules.google.com/task/1620087171184734180) started by @brewmarsh*