### PR TITLE
Fix Data & Logic (Rivalry & Match Names)

### DIFF
--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -343,8 +343,8 @@ def view_group(group_id):
                 ["player2", "player2Id", "player2_id", "opponent1", "opponent1Id"],
             )
         )
-        player_ids.add(get_id(match_data, ["partner", "partnerId", "partner_id"]))
-        player_ids.add(get_id(match_data, ["opponent2", "opponent2Id", "opponent2_id"]))
+        player_ids.add(get_id(match_data, ["partnerId", "partner", "partner_id"]))
+        player_ids.add(get_id(match_data, ["opponent2Id", "opponent2", "opponent2_id"]))
     player_ids.discard(None)
 
     users_map = {}
@@ -377,12 +377,10 @@ def view_group(group_id):
             {"username": "Unknown"},
         )
         match_data["partner"] = users_map.get(
-            get_id(match_data, ["partner", "partnerId", "partner_id"]),
-            {"username": "Unknown"},
+            get_id(match_data, ["partnerId", "partner", "partner_id"])
         )
         match_data["opponent2"] = users_map.get(
-            get_id(match_data, ["opponent2", "opponent2Id", "opponent2_id"]),
-            {"username": "Unknown"},
+            get_id(match_data, ["opponent2Id", "opponent2", "opponent2_id"])
         )
 
         # --- Giant Slayer Logic ---
@@ -780,6 +778,7 @@ def get_head_to_head_stats(group_id):
     partnership_losses = 0
     point_differential = 0
     h2h_matches_count = 0
+    partnership_matches_count = 0
 
     for match in matches:
         team1 = {match.get("player1Id"), match.get("partnerId")}
@@ -790,6 +789,7 @@ def get_head_to_head_stats(group_id):
         )
 
         if is_partner:
+            partnership_matches_count += 1
             # Determine which team they were on
             their_team = "team1" if player1_id in team1 else "team2"
             if match.get("winner") == their_team:
@@ -820,6 +820,8 @@ def get_head_to_head_stats(group_id):
 
     return {
         "total_matches": total_matches,
+        "h2h_matches_count": h2h_matches_count,
+        "partnership_matches_count": partnership_matches_count,
         "head_to_head_record": f"{h2h_player1_wins}-{h2h_player2_wins}",
         "partnership_record": f"{partnership_wins}-{partnership_losses}",
         "avg_point_differential": round(avg_point_differential, 1),

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -102,7 +102,7 @@
                     <select id="player1-select" class="form-control">
                         <option value="">Select a player</option>
                         {% for member in members %}
-                            <option value="{{ member.id }}">{{ member.username }}</option>
+                            <option value="{{ member.id }}">{{ member.username or member.name }}</option>
                         {% endfor %}
                     </select>
                 </div>
@@ -111,7 +111,7 @@
                     <select id="player2-select" class="form-control">
                         <option value="">Select a player</option>
                         {% for member in members %}
-                            <option value="{{ member.id }}">{{ member.username }}</option>
+                            <option value="{{ member.id }}">{{ member.username or member.name }}</option>
                         {% endfor %}
                     </select>
                 </div>
@@ -128,8 +128,8 @@
                     <thead>
                         <tr>
                             <th>Date</th>
-                            <th>Player 1</th>
-                            <th>Player 2</th>
+                            <th>Team 1</th>
+                            <th>Team 2</th>
                             <th>Score</th>
                         </tr>
                     </thead>
@@ -137,20 +137,26 @@
                         {% for match in recent_matches %}
                         <tr>
                             <td data-label="Date">{{ match.matchDate.strftime('%Y-%m-%d') if match.matchDate else 'N/A' }}</td>
-                            <td data-label="Player 1">
-                                {{ match.player1.username }}
-                                {% if match.is_upset and match.winner_id == match.player1.id %}
+                            <td data-label="Team 1">
+                                <a href="{{ url_for('user.view_user', user_id=match.player1.id) }}">{{ match.player1.username }}</a>
+                                {% if match.partner and match.partner.username != 'Unknown' %}
+                                    / <a href="{{ url_for('user.view_user', user_id=match.partner.id) }}">{{ match.partner.username }}</a>
+                                {% endif %}
+                                {% if match.is_upset and match.winner == 'team1' %}
                                     <span title="Giant Slayer! Beat a higher-ranked opponent.">🗡️</span>
                                 {% endif %}
                             </td>
-                            <td data-label="Player 2">
-                                {{ match.player2.username }}
-                                {% if match.is_upset and match.winner_id == match.player2.id %}
+                            <td data-label="Team 2">
+                                <a href="{{ url_for('user.view_user', user_id=match.player2.id) }}">{{ match.player2.username }}</a>
+                                {% if match.opponent2 and match.opponent2.username != 'Unknown' %}
+                                    / <a href="{{ url_for('user.view_user', user_id=match.opponent2.id) }}">{{ match.opponent2.username }}</a>
+                                {% endif %}
+                                {% if match.is_upset and match.winner == 'team2' %}
                                     <span title="Giant Slayer! Beat a higher-ranked opponent.">🗡️</span>
                                 {% endif %}
                             </td>
                             <td data-label="Score" {% if match.is_upset %}style="font-weight: bold; color: green;"{% endif %}>
-                                {{ match.player1Score }} - {{ match.player2Score }}
+                                {{ match.team1Score }} - {{ match.team2Score }}
                             </td>
                         </tr>
                         {% endfor %}
@@ -340,19 +346,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 const totalPartnerGames = partnerWins + partnerLosses;
                 const partnerWinRate = totalPartnerGames > 0 ? (partnerWins / totalPartnerGames) * 100 : 0;
 
-                let leaderMessage = '';
-                if (p1H2HWins > p2H2HWins) {
-                    leaderMessage = `${player1Name} leads the rivalry.`;
-                } else if (p2H2HWins > p1H2HWins) {
-                    leaderMessage = `${player2Name} leads the rivalry.`;
-                } else if (totalH2H > 0) {
-                    leaderMessage = 'The rivalry is tied.';
-                }
-
-                const statsHtml = `
-                    <div class="stats-grid">
+                let h2hHtml = '';
+                if (data.h2h_matches_count > 0) {
+                    h2hHtml = `
                         <div class="stat-card">
-                            <h5>Head-to-Head</h5>
+                            <h5>Head-to-Head (${data.h2h_matches_count} matches)</h5>
                             <div class="h2h-scores">
                                 <span class="player-name">${player1Name}</span>
                                 <span class="score">${p1H2HWins} - ${p2H2HWins}</span>
@@ -365,14 +363,36 @@ document.addEventListener('DOMContentLoaded', function() {
                             <p class="leader-message">${leaderMessage}</p>
                         </div>
                         <div class="stat-card">
-                            <h5>As Partners</h5>
-                            <p><strong>Record:</strong> ${partnerWins}W - ${partnerLosses}L</p>
-                            <p><strong>Win Rate:</strong> ${partnerWinRate.toFixed(1)}%</p>
-                        </div>
-                        <div class="stat-card">
                             <h5>Point Differential</h5>
                             <p>Avg. <strong>${data.avg_point_differential > 0 ? '+' : ''}${data.avg_point_differential}</strong> points for ${player1Name}</p>
                         </div>
+                    `;
+                }
+
+                let partnershipHtml = '';
+                if (data.partnership_matches_count > 0) {
+                    partnershipHtml = `
+                        <div class="stat-card">
+                            <h5>As Partners (${data.partnership_matches_count} matches)</h5>
+                            <p><strong>Record:</strong> ${partnerWins}W - ${partnerLosses}L</p>
+                            <p><strong>Win Rate:</strong> ${partnerWinRate.toFixed(1)}%</p>
+                        </div>
+                    `;
+                }
+
+                let leaderMessage = '';
+                if (p1H2HWins > p2H2HWins) {
+                    leaderMessage = `${player1Name} leads the rivalry.`;
+                } else if (p2H2HWins > p1H2HWins) {
+                    leaderMessage = `${player2Name} leads the rivalry.`;
+                } else if (totalH2H > 0) {
+                    leaderMessage = 'The rivalry is tied.';
+                }
+
+                const statsHtml = `
+                    <div class="stats-grid">
+                        ${h2hHtml}
+                        ${partnershipHtml}
                     </div>
                 `;
 


### PR DESCRIPTION
This change fixes the match history and rivalry logic in the group view. It ensures that all players in a doubles match are correctly displayed, and it updates the rivalry statistics to differentiate between head-to-head and partnership records. The rivalry dropdowns have also been updated to provide a fallback to a user's name if a username is not set.

Fixes #518

---
*PR created automatically by Jules for task [2323683477778187409](https://jules.google.com/task/2323683477778187409) started by @brewmarsh*