### PR TITLE
Fix Mobile Layout for Group View

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -387,8 +387,9 @@ input[type="submit"], .btn {
 
 .grid-container {
     display: grid;
-    grid-template-columns: 1fr 2fr;
+    grid-template-columns: 1fr 1fr;
     gap: 20px;
+    align-items: start;
 }
 
 /* Match Cards */
@@ -985,4 +986,17 @@ input[type="submit"], .btn {
 .rivalry-vs {
     font-weight: bold;
     font-size: 1.2em;
+}
+
+@media (max-width: 768px) {
+  .grid-container {
+    grid-template-columns: 1fr;
+  }
+  .group-header-actions {
+    flex-wrap: wrap;
+  }
+  .group-header-actions > .btn {
+    width: 100%;
+    margin-top: 10px;
+  }
 }

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -23,7 +23,7 @@
     </div>
 </div>
 
-<div class="grid-container" style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; align-items: start;">
+<div class="grid-container">
     
     <div>
         <div class="card">


### PR DESCRIPTION
This change fixes the broken mobile layout for the Group View page. It introduces a media query to stack the "Leaderboard" and "Rivalry" cards vertically on screens smaller than 768px. It also ensures the header content wraps correctly and makes the "Record a Match" button full-width for better mobile usability. Additionally, it refactors inline styles from the HTML template into the main stylesheet to improve maintainability and ensure the responsive styles are applied correctly.

Fixes #529

---
*PR created automatically by Jules for task [15999153968706025499](https://jules.google.com/task/15999153968706025499) started by @brewmarsh*