### PR TITLE
refactor: Clean up UI by removing unnecessary text

### DIFF
--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -59,7 +59,7 @@
                                 </span>
                             </div>
                         </div>
-                        <div class="leaderboard-cell" data-label="Player">
+                        <div class="leaderboard-cell" data-label="">
                             <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link">
                                 <img src="{{ player.profilePictureUrl or url_for('static', filename='user_icon.png') }}" alt="{{ player.name }}" class="profile-picture-thumbnail">
                                 <span class="player-name">

--- a/pickaladder/templates/groups.html
+++ b/pickaladder/templates/groups.html
@@ -13,7 +13,7 @@
             <tbody>
                 {% for membership in my_groups %}
                 <tr class="clickable-row" data-href="{{ url_for('group.view_group', group_id=membership.group.id) }}">
-                    <td data-label="Group">
+                    <td data-label="">
                         <img src="{{ membership.group.profilePictureUrl if membership.group.profilePictureUrl else url_for('static', filename='user_icon.png') }}" alt="Group Picture" class="profile-picture-thumbnail">
                         <strong>{{ membership.group.name }}</strong><br>
                         <small>Owned by: {{ membership.group.owner.username }}</small>
@@ -41,7 +41,7 @@
             <tbody>
                 {% for group in pagination.items %}
                 <tr class="clickable-row" data-href="{{ url_for('group.view_group', group_id=group.id) }}">
-                    <td data-label="Group">
+                    <td data-label="">
                         <img src="{{ group.profilePictureUrl if group.profilePictureUrl else url_for('static', filename='user_icon.png') }}" alt="Group Picture" class="profile-picture-thumbnail">
                         <strong>{{ group.name }}</strong><br>
                         <small>Owned by: {{ group.owner.username }}</small><br>

--- a/pickaladder/templates/leaderboard.html
+++ b/pickaladder/templates/leaderboard.html
@@ -10,7 +10,7 @@
             <thead>
                 <tr>
                     <th>Rank</th>
-                    <th>Player</th>
+                    <th></th>
                     <th>Win Percentage</th>
                     <th>Games Played</th>
                 </tr>
@@ -19,7 +19,7 @@
                 {% for player in players %}
                 <tr class="{{ 'highlight-row' if player.id == current_user_id else '' }}">
                     <td data-label="Rank" class="{% if loop.index == 1 %}rank-1{% elif loop.index == 2 %}rank-2{% elif loop.index == 3 %}rank-3{% endif %}">{{ loop.index }}</td>
-                    <td data-label="Player"><a href="{{ url_for('user.view_user', user_id=player.id) }}">{{ player.name }}</a></td>
+                    <td data-label=""><a href="{{ url_for('user.view_user', user_id=player.id) }}">{{ player.name }}</a></td>
                     <td data-label="Win Percentage">{{ "%.2f"|format(player.win_percentage|float) }}%</td>
                     <td data-label="Games Played">{{ player.games_played }}</td>
                 </tr>


### PR DESCRIPTION
This change removes unnecessary text from the UI to make it cleaner and less cluttered. Specifically, it removes the "Player" and "Group" labels from various leaderboards and lists.

Fixes #535

---
*PR created automatically by Jules for task [18277704007892354239](https://jules.google.com/task/18277704007892354239) started by @brewmarsh*