### PR TITLE
Fix Mobile Layout (Space Saving)

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -989,6 +989,9 @@ input[type="submit"], .btn {
 }
 
 @media (max-width: 768px) {
+    body {
+        overflow-x: hidden;
+    }
     .leaderboard-header {
         display: none;
     }
@@ -1003,12 +1006,18 @@ input[type="submit"], .btn {
         justify-content: space-between;
         align-items: center;
         grid-template-columns: none; /* Override grid layout */
-        padding: 16px 12px;
+        padding: 16px 8px;
     }
 
     .leaderboard-row .profile-picture-thumbnail {
+        width: 32px;
+        height: 32px;
         flex-shrink: 0;
         margin-right: 15px;
+    }
+
+    .player-name {
+        font-size: 0.9rem;
     }
 
     .leaderboard-cell[data-label="Player"] {


### PR DESCRIPTION
I have successfully optimized the Group Leaderboard for mobile screens by applying the requested CSS changes. The layout is now more compact, and horizontal scrolling is prevented. I have verified the changes with a screenshot.

Fixes #537

---
*PR created automatically by Jules for task [11215269690235358991](https://jules.google.com/task/11215269690235358991) started by @brewmarsh*