### PR TITLE
Fix Mobile Leaderboard Layout

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -1006,7 +1006,7 @@ input[type="submit"], .btn {
         justify-content: space-between;
         align-items: center;
         grid-template-columns: none; /* Override grid layout */
-        padding: 16px 8px;
+        padding: 8px;
     }
 
     .leaderboard-row .profile-picture-thumbnail {

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -59,7 +59,7 @@
                                 </span>
                             </div>
                         </div>
-                        <div class="leaderboard-cell" data-label="">
+                        <div class="leaderboard-cell" data-label="Player">
                             <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link">
                                 <img src="{{ player.profilePictureUrl or url_for('static', filename='user_icon.png') }}" alt="{{ player.name }}" class="profile-picture-thumbnail">
                                 <span class="player-name">


### PR DESCRIPTION
This change fixes the mobile layout of the Group Leaderboard. It corrects a broken CSS selector by updating a `data-label` attribute in the HTML, which allows the mobile-specific flexbox styles to apply correctly. It also reduces the padding on leaderboard rows to create a more compact and space-efficient design, as requested by the user. The fix has been verified visually with screenshots and by running the full test suite.

Fixes #537

---
*PR created automatically by Jules for task [924477959185548633](https://jules.google.com/task/924477959185548633) started by @brewmarsh*