### PR TITLE
Implement Doubles Teams Logic

### DIFF
--- a/pickaladder/teams/models.py
+++ b/pickaladder/teams/models.py
@@ -16,7 +16,10 @@ def create_team_document(db, team_members):
     """
     sorted_members = sorted(team_members, key=lambda doc_ref: doc_ref.id)
     member_ids = [doc_ref.id for doc_ref in sorted_members]
-    team_name = " & ".join([doc_ref.get().to_dict().get("name", "Unknown") for doc_ref in sorted_members])
+    member_names = [
+        doc_ref.get().to_dict().get("name", "Unknown") for doc_ref in sorted_members
+    ]
+    team_name = " & ".join(member_names)
 
     team_data = {
         "members": sorted_members,


### PR DESCRIPTION
This change introduces a formal 'Teams' data model for doubles matches, including a new schema definition and a migration script to populate the database with team data from existing matches. The migration script is idempotent and can be run multiple times without creating duplicate teams. This fulfills the user's request to implement the 'Teams' feature.

Fixes #549

---
*PR created automatically by Jules for task [17657993469092615773](https://jules.google.com/task/17657993469092615773) started by @brewmarsh*