### PR TITLE
Create Team Leaderboard

### DIFF
--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -154,6 +154,88 @@ def view_group(group_id):
 
     is_member = current_user_id in member_ids
 
+    # --- Team Leaderboard ---
+    team_leaderboard = []
+    teams_ref = db.collection("teams")
+    if member_ids:
+        member_id_list = list(member_ids)
+        team_docs_map = {}  # Use a map to prevent duplicates
+
+        # Chunk the query to handle Firestore's 30-item limit for 'in'/'array-contains-any' queries
+        for i in range(0, len(member_id_list), 30):
+            chunk = member_id_list[i : i + 30]
+            query = teams_ref.where(
+                filter=firestore.FieldFilter("member_ids", "array_contains_any", chunk)
+            )
+            for doc in query.stream():
+                team_docs_map[doc.id] = doc
+
+        all_team_docs = list(team_docs_map.values())
+
+        # Filter teams to include only those where all members are in the group
+        group_teams = [
+            team_doc
+            for team_doc in all_team_docs
+            if all(
+                member_id in member_ids for member_id in team_doc.to_dict()["member_ids"]
+            )
+        ]
+
+        # Batch fetch all team member details to avoid N+1 queries
+        all_member_refs = []
+        for team_doc in group_teams:
+            team_data = team_doc.to_dict()
+            if "members" in team_data:
+                all_member_refs.extend(team_data.get("members", []))
+
+        members_map = {}
+        if all_member_refs:
+            # Deduplicate refs by their path
+            unique_member_refs = list({ref.path: ref for ref in all_member_refs}.values())
+            member_docs = db.get_all(unique_member_refs)
+            members_map = {doc.id: doc.to_dict() for doc in member_docs if doc.exists}
+
+        # Enrich and calculate stats for the leaderboard
+        for team_doc in group_teams:
+            team_data = team_doc.to_dict()
+            team_data["id"] = team_doc.id
+            stats = team_data.get("stats", {})
+            wins = stats.get("wins", 0)
+            losses = stats.get("losses", 0)
+            total_games = wins + losses
+            team_data["win_percentage"] = (
+                (wins / total_games) * 100 if total_games > 0 else 0
+            )
+            team_data["total_games"] = total_games
+
+            # Get member details from the pre-fetched map
+            team_members = []
+            member_ids_for_team = team_data.get("member_ids", [])
+            for member_id in member_ids_for_team:
+                if member_id in members_map:
+                    member_data = members_map[member_id]
+                    member_data["id"] = member_id
+                    team_members.append(member_data)
+            team_data["member_details"] = team_members
+
+            # To handle user name changes, we regenerate the default team name.
+            # This assumes that if a custom name is set, it won't follow the "A & B" pattern.
+            # A more robust solution would require a database schema change (e.g., is_name_custom flag).
+            if len(team_members) == 2:
+                member_names = [
+                    m.get("name") or m.get("username", "Unknown") for m in team_members
+                ]
+                generated_name = " & ".join(member_names)
+
+                # Simple heuristic: if the stored name has a " & ", it's likely a default name that needs refreshing.
+                if " & " in team_data.get("name", ""):
+                    team_data["name"] = generated_name
+
+            team_leaderboard.append(team_data)
+
+        # Sort teams by win percentage
+        team_leaderboard.sort(key=lambda x: x["win_percentage"], reverse=True)
+
     # --- Fetch Pending Invites ---
     pending_members = []
     if is_member:
@@ -495,6 +577,7 @@ def view_group(group_id):
         is_member=is_member,
         recent_matches=recent_matches,
         best_buds=best_buds,
+        team_leaderboard=team_leaderboard,
     )
 
 

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -31,64 +31,120 @@
         <div class="card">
             <h3>Group Leaderboard</h3>
             <p>A live ranking of all group members.</p>
-            <div class="leaderboard-container">
-                <div class="leaderboard-header">
-                    <div class="leaderboard-cell">Rank</div>
-                    <div class="leaderboard-cell">Player</div>
-                    <div class="leaderboard-cell">Avg. Score</div>
-                    <div class="leaderboard-cell">Form</div>
-                    <div class="leaderboard-cell">Games</div>
+
+            <div class="tab-container">
+                <div class="tab-buttons">
+                    <button class="tab-button active" onclick="openTab(event, 'players')">Players</button>
+                    <button class="tab-button" onclick="openTab(event, 'teams')">Teams</button>
                 </div>
-                <div class="leaderboard-body">
-                    {% for player in leaderboard %}
-                    <div class="leaderboard-row {{ 'highlight-user' if player.id == g.user['uid'] else '' }}">
-                        <div class="leaderboard-cell" data-label="Rank">
-                            <div class="player-rank">
-                                <span>
-                                    {% if loop.index == 1 %}🥇
-                                    {% elif loop.index == 2 %}🥈
-                                    {% elif loop.index == 3 %}🥉
-                                    {% else %}{{ loop.index }}{% endif %}
-                                </span>
-                                <span class="rank-trend">
-                                    {% if player.rank_change is number and player.rank_change > 0 %}
-                                        <span class="trend-up">▲</span>
-                                    {% elif player.rank_change is number and player.rank_change < 0 %}
-                                        <span class="trend-down">▼</span>
-                                    {% elif player.rank_change == 'new' %}
-                                        <span class="trend-new">●</span>
-                                    {% endif %}
-                                </span>
+
+                <div id="players" class="tab-content" style="display: block;">
+                    <div class="leaderboard-container">
+                        <div class="leaderboard-header">
+                            <div class="leaderboard-cell">Rank</div>
+                            <div class="leaderboard-cell">Player</div>
+                            <div class="leaderboard-cell">Avg. Score</div>
+                            <div class="leaderboard-cell">Form</div>
+                            <div class="leaderboard-cell">Games</div>
+                        </div>
+                        <div class="leaderboard-body">
+                            {% for player in leaderboard %}
+                            <div class="leaderboard-row {{ 'highlight-user' if player.id == g.user['uid'] else '' }}">
+                                <div class="leaderboard-cell" data-label="Rank">
+                                    <div class="player-rank">
+                                        <span>
+                                            {% if loop.index == 1 %}🥇
+                                            {% elif loop.index == 2 %}🥈
+                                            {% elif loop.index == 3 %}🥉
+                                            {% else %}{{ loop.index }}{% endif %}
+                                        </span>
+                                        <span class="rank-trend">
+                                            {% if player.rank_change is number and player.rank_change > 0 %}
+                                                <span class="trend-up">▲</span>
+                                            {% elif player.rank_change is number and player.rank_change < 0 %}
+                                                <span class="trend-down">▼</span>
+                                            {% elif player.rank_change == 'new' %}
+                                                <span class="trend-new">●</span>
+                                            {% endif %}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="leaderboard-cell" data-label="Player">
+                                    <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link">
+                                        <img src="{{ player.profilePictureUrl or url_for('static', filename='user_icon.png') }}" alt="{{ player.name }}" class="profile-picture-thumbnail">
+                                        <span class="player-name">
+                                            {{ player.name }}
+                                            {% if player.is_on_fire %}
+                                                <span title="{{ player.streak }} Game Streak!">🔥</span>
+                                            {% endif %}
+                                        </span>
+                                    </a>
+                                </div>
+                                <div class="leaderboard-cell" data-label="Avg. Score">{{ "%.2f"|format(player.avg_score|float) }}</div>
+                                <div class="leaderboard-cell" data-label="Form">
+                                    <div class="form-dots">
+                                        {% for result in player.form %}
+                                            <span class="form-dot {{ result }}"></span>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <div class="leaderboard-cell" data-label="Games">{{ player.games_played }}</div>
                             </div>
-                        </div>
-                        <div class="leaderboard-cell" data-label="Player">
-                            <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link">
-                                <img src="{{ player.profilePictureUrl or url_for('static', filename='user_icon.png') }}" alt="{{ player.name }}" class="profile-picture-thumbnail">
-                                <span class="player-name">
-                                    {{ player.name }}
-                                    {% if player.is_on_fire %}
-                                        <span title="{{ player.streak }} Game Streak!">🔥</span>
-                                    {% endif %}
-                                </span>
-                            </a>
-                        </div>
-                        <div class="leaderboard-cell" data-label="Avg. Score">{{ "%.2f"|format(player.avg_score|float) }}</div>
-                        <div class="leaderboard-cell" data-label="Form">
-                            <div class="form-dots">
-                                {% for result in player.form %}
-                                    <span class="form-dot {{ result }}"></span>
-                                {% endfor %}
+                            {% else %}
+                            <div class="leaderboard-empty">
+                                <p>No matches have been played between members of this group yet.</p>
                             </div>
+                            {% endfor %}
                         </div>
-                        <div class="leaderboard-cell" data-label="Games">{{ player.games_played }}</div>
                     </div>
-                    {% else %}
-                    <div class="leaderboard-empty">
-                        <p>No matches have been played between members of this group yet.</p>
+                </div>
+
+                <div id="teams" class="tab-content" style="display: none;">
+                    <div class="leaderboard-container">
+                        <div class="leaderboard-header">
+                            <div class="leaderboard-cell">Rank</div>
+                            <div class="leaderboard-cell">Team</div>
+                            <div class="leaderboard-cell">Win %</div>
+                            <div class="leaderboard-cell">Record</div>
+                            <div class="leaderboard-cell">Games</div>
+                        </div>
+                        <div class="leaderboard-body">
+                            {% for team in team_leaderboard %}
+                            <div class="leaderboard-row">
+                                <div class="leaderboard-cell" data-label="Rank">
+                                    <div class="player-rank">
+                                        <span>
+                                            {% if loop.index == 1 %}🥇
+                                            {% elif loop.index == 2 %}🥈
+                                            {% elif loop.index == 3 %}🥉
+                                            {% else %}{{ loop.index }}{% endif %}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="leaderboard-cell" data-label="Team">
+                                    <div class="team-members">
+                                        {% for member in team.member_details %}
+                                            <a href="{{ url_for('user.view_user', user_id=member.id) }}" class="player-link">
+                                                <img src="{{ member.profilePictureUrl or url_for('static', filename='user_icon.png') }}" alt="{{ member.name }}" class="profile-picture-thumbnail">
+                                            </a>
+                                        {% endfor %}
+                                        <span class="team-name">{{ team.name }}</span>
+                                    </div>
+                                </div>
+                                <div class="leaderboard-cell" data-label="Win %">{{ "%.1f"|format(team.win_percentage) }}%</div>
+                                <div class="leaderboard-cell" data-label="Record">{{ team.stats.get('wins', 0) }}-{{ team.stats.get('losses', 0) }}</div>
+                                <div class="leaderboard-cell" data-label="Games">{{ team.total_games }}</div>
+                            </div>
+                            {% else %}
+                            <div class="leaderboard-empty">
+                                <p>No teams have been formed in this group yet.</p>
+                            </div>
+                            {% endfor %}
+                        </div>
                     </div>
-                    {% endfor %}
                 </div>
             </div>
+
             <div class="leaderboard-trend-link">
                 <a href="{{ url_for('group.view_leaderboard_trend', group_id=group.id) }}">View Leaderboard Trend Chart</a>
             </div>
@@ -336,6 +392,20 @@
 {% endif %}
 
 <script>
+function openTab(evt, tabName) {
+    var i, tabcontent, tabbuttons;
+    tabcontent = document.getElementsByClassName("tab-content");
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
+    tabbuttons = document.getElementsByClassName("tab-button");
+    for (i = 0; i < tabbuttons.length; i++) {
+        tabbuttons[i].className = tabbuttons[i].className.replace(" active", "");
+    }
+    document.getElementById(tabName).style.display = "block";
+    evt.currentTarget.className += " active";
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     const player1Select = document.getElementById('player1-select');
     const player2Select = document.getElementById('player2-select');


### PR DESCRIPTION
This change introduces a team leaderboard to the group view. It includes a tabbed interface to switch between player and team rankings, an efficient backend query to fetch and rank teams, and a fallback for team names.

Fixes #552

---
*PR created automatically by Jules for task [7182091202691758703](https://jules.google.com/task/7182091202691758703) started by @brewmarsh*