### PR TITLE
Add "Edit Team Name" Feature

### DIFF
--- a/pickaladder/group/utils.py
+++ b/pickaladder/group/utils.py
@@ -642,9 +642,13 @@ def _get_recent_matches_and_players(db, recent_matches_docs: list) -> list:
 
         # Populate Teams
         if team1_ref := match_data.get("team1Ref"):
-            match_data["team1"] = teams_map.get(team1_ref.id)
+            if team_data := teams_map.get(team1_ref.id):
+                team_data["id"] = team1_ref.id
+                match_data["team1"] = team_data
         if team2_ref := match_data.get("team2Ref"):
-            match_data["team2"] = teams_map.get(team2_ref.id)
+            if team_data := teams_map.get(team2_ref.id):
+                team_data["id"] = team2_ref.id
+                match_data["team2"] = team_data
 
         # Populate Players (as fallback and for older match types)
         if p1_ref := match_data.get("player1Ref"):

--- a/pickaladder/teams/forms.py
+++ b/pickaladder/teams/forms.py
@@ -5,8 +5,8 @@ from wtforms import StringField, SubmitField
 from wtforms.validators import DataRequired
 
 
-class RenameTeamForm(FlaskForm):
-    """Form to rename a team."""
+class EditTeamNameForm(FlaskForm):
+    """Form to edit a team's name."""
 
     name = StringField("Team Name", validators=[DataRequired()])
-    submit = SubmitField("Rename Team")
+    submit = SubmitField("Save Changes")

--- a/pickaladder/teams/routes.py
+++ b/pickaladder/teams/routes.py
@@ -6,7 +6,7 @@ from flask import flash, g, redirect, render_template, url_for
 from pickaladder.auth.decorators import login_required
 
 from . import bp
-from .forms import RenameTeamForm
+from .forms import EditTeamNameForm
 
 
 @bp.route("/<string:team_id>")
@@ -144,10 +144,10 @@ def view_team(team_id):
     )
 
 
-@bp.route("/<string:team_id>/rename", methods=["GET", "POST"])
+@bp.route("/<string:team_id>/edit", methods=["GET", "POST"])
 @login_required
-def rename_team(team_id):
-    """Rename a team."""
+def edit_team(team_id):
+    """Edit a team's name."""
     db = firestore.client()
     team_ref = db.collection("teams").document(team_id)
     team = team_ref.get()
@@ -164,7 +164,7 @@ def rename_team(team_id):
         flash("You do not have permission to rename this team.", "danger")
         return redirect(url_for(".view_team", team_id=team_id))
 
-    form = RenameTeamForm()
+    form = EditTeamNameForm()
     if form.validate_on_submit():
         try:
             team_ref.update({"name": form.name.data})
@@ -174,4 +174,4 @@ def rename_team(team_id):
             flash(f"An unexpected error occurred: {e}", "danger")
 
     form.name.data = team_data.get("name")
-    return render_template("team/rename_team.html", form=form, team=team_data)
+    return render_template("team/edit.html", form=form, team=team_data)

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -214,6 +214,9 @@
                             <td data-label="Team 1">
                                 {% if match.team1 %}
                                     {{ match.team1.name }}
+                                    {% if g.user and g.user.uid in match.team1.member_ids %}
+                                        <a href="{{ url_for('teams.edit_team', team_id=match.team1.id) }}" class="icon-link" title="Edit Team Name">✏️</a>
+                                    {% endif %}
                                 {% elif match.player1 %}
                                     {% if match.player1.id != 'unknown' %}
                                         <a href="{{ url_for('user.view_user', user_id=match.player1.id) }}">{{ match.player1.username }}</a>
@@ -238,6 +241,9 @@
                             <td data-label="Team 2">
                                 {% if match.team2 %}
                                     {{ match.team2.name }}
+                                    {% if g.user and g.user.uid in match.team2.member_ids %}
+                                        <a href="{{ url_for('teams.edit_team', team_id=match.team2.id) }}" class="icon-link" title="Edit Team Name">✏️</a>
+                                    {% endif %}
                                 {% elif match.player2 %}
                                     {% if match.player2.id != 'unknown' %}
                                         <a href="{{ url_for('user.view_user', user_id=match.player2.id) }}">{{ match.player2.username }}</a>

--- a/pickaladder/templates/team/edit.html
+++ b/pickaladder/templates/team/edit.html
@@ -1,8 +1,8 @@
 {% extends "layout.html" %}
-{% block title %}Rename Team{% endblock %}
+{% block title %}Edit Team Name{% endblock %}
 {% block content %}
 <div class="form-container">
-    <h2>Rename Team: {{ team.name }}</h2>
+    <h2>Edit Team Name: {{ team.name }}</h2>
     <form method="post">
         {{ form.hidden_tag() }}
         <div class="form-group">


### PR DESCRIPTION
This change adds a new feature that allows users to edit their team names. An edit icon is now displayed next to team names in the "Recent Matches" table, which is visible only to team members. The form, route, and template have been updated to support this new functionality.

Fixes #571

---
*PR created automatically by Jules for task [9376487587439393851](https://jules.google.com/task/9376487587439393851) started by @brewmarsh*