### PR TITLE
Create Team Index Definition

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+"indexes": [
+{
+"collectionGroup": "matches",
+"queryScope": "COLLECTION",
+"fields": [
+{ "fieldPath": "team1Ref", "order": "ASCENDING" },
+{ "fieldPath": "matchDate", "order": "DESCENDING" }
+]
+},
+{
+"collectionGroup": "matches",
+"queryScope": "COLLECTION",
+"fields": [
+{ "fieldPath": "team2Ref", "order": "ASCENDING" },
+{ "fieldPath": "matchDate", "order": "DESCENDING" }
+]
+}
+],
+"fieldOverrides": []
+}


### PR DESCRIPTION
This change introduces a `firestore.indexes.json` file to define the necessary composite indexes for the `matches` collection. By creating these indexes, we can avoid Firestore errors that occur when querying a team's match history. The new indexes are defined on `team1Ref` and `team2Ref`, both in ascending order, combined with `matchDate` in descending order, to support efficient querying of match data.

Fixes #574

---
*PR created automatically by Jules for task [1147038186259457024](https://jules.google.com/task/1147038186259457024) started by @brewmarsh*