### PR TITLE
Polish Mobile Layout CSS

### DIFF
--- a/pickaladder/static/mobile.css
+++ b/pickaladder/static/mobile.css
@@ -56,6 +56,15 @@
     .grid-container {
         grid-template-columns: 1fr;
     }
+
+    .card {
+        margin-bottom: 16px;
+    }
+
+    .rivalry-check-form {
+        flex-direction: column;
+    }
+
     .responsive-table {
         width: 100%;
         border-collapse: collapse;
@@ -140,6 +149,7 @@
     }
 
     .leaderboard-row {
+        display: grid;
         grid-template-columns: 1fr;
         grid-template-areas:
             "player"
@@ -175,6 +185,7 @@
         content: attr(data-label);
         font-weight: 600;
         color: var(--on-surface-variant-color);
+        margin-right: 8px;
     }
 
     .player-rank {


### PR DESCRIPTION
This PR polishes the mobile layout by addressing several spacing and layout issues:
- Cards now have a 16px bottom margin on mobile to prevent them from touching.
- The Rivalry Check dropdowns now stack vertically for better usability on small screens.
- In the mobile leaderboard view, labels like 'Games' and 'Form' now have a margin between them and their values, preventing them from being squashed (e.g., 'Games 25' instead of 'Games25').
- Fixed a bug where .leaderboard-row was missing 'display: grid', which prevented the mobile-specific grid layout from being applied correctly.

Fixes #589

---
*PR created automatically by Jules for task [15677023665673881140](https://jules.google.com/task/15677023665673881140) started by @brewmarsh*