### PR TITLE
Emergency Fix: Friends Page Mobile Layout

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -397,6 +397,12 @@ input[type="submit"], .btn {
     align-items: start;
 }
 
+.friends-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+}
+
 /* Match Cards */
 .match-card {
     background-color: var(--surface-color);
@@ -975,6 +981,39 @@ input[type="submit"], .btn {
 
     .stats-grid {
         grid-template-columns: repeat(2, 1fr);
+    }
+
+    .friends-container {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+
+    .friends-container .card {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .friends-header-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .friends-header-actions .btn {
+        width: 100%;
+        margin-top: 0;
+    }
+
+    .responsive-table td {
+        padding-left: 16px !important;
+    }
+
+    .responsive-table td::before {
+        display: block !important;
+        position: static !important;
+        width: 100% !important;
+        margin-bottom: 4px !important;
+        text-align: left !important;
     }
 }
 

--- a/pickaladder/templates/friends.html
+++ b/pickaladder/templates/friends.html
@@ -3,14 +3,14 @@
 {% block content %}
     <div class="page-header">
         <h1>Friends</h1>
-        <div>
+        <div class="friends-header-actions">
             <button id="invite-friend-btn" class="btn" data-csrf="{{ csrf_token() }}">Invite a Friend</button>
             <a href="{{ url_for('user.users') }}" class="btn">Find New Friends</a>
         </div>
     </div>
     <div id="invite-success-message" class="alert alert-success" style="display: none;"></div>
 
-    <div class="grid-container" style="grid-template-columns: 1fr 1fr; gap: 40px;">
+    <div class="friends-container">
         <div class="card">
             <h3>Your Friends</h3>
             <div class="table-container">


### PR DESCRIPTION
The mobile layout of the Friends page was broken, with overlapping text and poorly sized buttons. This PR fixes these issues by:
1. Moving inline grid styles to a CSS class and using a media query to force a single-column stack on screens smaller than 768px.
2. Ensuring friend cards take up 100% of the width on mobile.
3. Redesigning the responsive table cells to stack labels vertically above their content, preventing the 'User' label from overlapping names.
4. Making the 'Invite' and 'Find' buttons full-width on mobile for easier tapping.
5. Cleaning up the template by removing inline styles.

Fixes #603

---
*PR created automatically by Jules for task [1202131347239296459](https://jules.google.com/task/1202131347239296459) started by @brewmarsh*