### PR TITLE
Restore and Repair main CSS stylesheet

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -1,3 +1,1044 @@
+/* Basic styling */
+:root {
+    --primary-brand: #0F4C81;
+    --primary-brand-dark: #0b3a64;
+    --accent-highlight: #DFFF00;
+    --success-color: #10B981;
+    --danger-color: #EA4335; /* Google Red */
+    --warning-color: #FBBC05; /* Google Yellow */
+    --text-color: #1F2937;
+    --text-secondary-color: #616161;
+    --background-color: #F3F4F6;
+    --surface-color: #FFFFFF;
+    --on-primary-color: #ffffff;
+    --border-color: #E0E0E0;
+    --font-family: 'Roboto', sans-serif;
+    --box-shadow: 0 1px 2px 0 rgba(60,64,67,0.302), 0 1px 3px 1px rgba(60,64,67,0.149);
+    --border-radius: 8px;
+}
+
+body {
+    font-family: var(--font-family);
+    margin: 0;
+    padding: 0;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.main-content {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+/* Page Header */
+.page-header {
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.page-header h1 {
+    margin: 0;
+    font-weight: 400;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.stat-card {
+    background-color: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    padding: 20px;
+    text-align: center;
+}
+
+.stat-card h3 {
+    margin-top: 0;
+    font-size: 1.2em;
+    color: var(--text-secondary-color);
+}
+
+.stat-card p {
+    font-size: 2em;
+    font-weight: 500;
+    margin-bottom: 0;
+}
+
+.winner-icon {
+    border: 4px solid var(--warning-color);
+    box-shadow: 0 0 10px var(--warning-color);
+}
+
+.loser-icon {
+    opacity: 0.6;
+}
+
+/* Header and Navbar */
+.header {
+    background-color: var(--primary-brand);
+    border-bottom: 1px solid var(--primary-brand-dark);
+    padding: 10px 0;
+    margin-bottom: 20px;
+}
+
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.navbar-brand {
+    font-size: 1.5em;
+    font-weight: 500;
+    color: var(--on-primary-color);
+    text-decoration: none;
+}
+
+.navbar-menu {
+    display: flex;
+    align-items: center;
+    gap: 20px; /* spacing between menu items */
+}
+
+.navbar-menu a {
+    text-decoration: none;
+    color: var(--on-primary-color);
+}
+
+
+.navbar-user-controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.hamburger-menu {
+    display: none;
+}
+
+.hamburger-menu, .navbar-right {
+    display: none;
+}
+
+.profile-picture-thumbnail {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+/* Forms */
+.form-container {
+    max-width: 500px;
+    margin: 40px auto;
+    padding: 32px;
+    background: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+.form-container h2 {
+    margin-top: 0;
+    text-align: center;
+    font-weight: 400;
+    font-size: 24px;
+    margin-bottom: 24px;
+}
+
+form {
+    margin-top: 20px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 500;
+    color: var(--text-secondary-color);
+    font-size: 14px;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="number"],
+input[type="date"],
+textarea,
+select {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-size: 16px;
+    background-color: var(--background-color);
+    color: var(--text-color);
+}
+
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="email"]:focus,
+input[type="number"]:focus,
+input[type="date"]:focus,
+textarea:focus,
+select:focus {
+    outline: none;
+    border-color: var(--primary-brand);
+    box-shadow: 0 0 0 2px rgba(15, 76, 129, 0.2);
+}
+
+textarea {
+    resize: vertical;
+}
+
+input,
+textarea,
+select {
+    user-select: auto !important;
+    -webkit-user-select: auto !important;
+    -moz-user-select: auto !important;
+    -ms-user-select: auto !important;
+}
+
+input[type="submit"], .btn {
+    background-color: var(--primary-brand);
+    color: var(--on-primary-color);
+    padding: 12px 24px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    text-decoration: none;
+    display: inline-block;
+    margin-top: 10px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+    transition: background-color 0.2s ease-in-out;
+    width: 100%;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.btn:hover {
+    background-color: var(--primary-brand-dark);
+}
+
+.btn-primary {
+    background-color: var(--accent-highlight);
+    color: #000000;
+}
+
+.btn-primary:hover {
+    background-color: var(--accent-highlight);
+    filter: brightness(90%);
+    color: #000000;
+}
+
+.btn-danger {
+    background-color: var(--danger-color);
+}
+
+.btn-warning {
+    background-color: var(--warning-color);
+    color: var(--text-color);
+}
+
+/* Tables */
+.table-container {
+    background-color: var(--surface-color);
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+.table th, .table td {
+    padding: 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.table th {
+    background-color: var(--primary-brand);
+    color: var(--on-primary-color);
+    font-weight: 500;
+    font-size: 14px;
+}
+
+.table tr:last-child td {
+    border-bottom: none;
+}
+
+/* Dropdown */
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropbtn {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    border-radius: 50%;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    right: 0;
+    background-color: var(--surface-color);
+    min-width: 220px;
+    box-shadow: var(--box-shadow);
+    z-index: 1;
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.dropdown-content a {
+    color: var(--text-color);
+    padding: 10px 20px;
+    text-decoration: none;
+    display: block;
+    font-size: 14px;
+}
+
+.dropdown-content a:hover {
+    background-color: var(--background-color);
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+/* Alerts */
+.flashes {
+    margin: 20px 0;
+}
+
+.alert {
+    padding: 15px;
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}
+
+.alert-danger {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+}
+
+.alert-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+}
+
+/* Admin Banner */
+.admin-banner {
+    background-color: var(--warning-color);
+    color: var(--text-color);
+    text-align: center;
+    padding: 4px;
+    font-size: 0.9em;
+    font-weight: 500;
+}
+
+/* Cards */
+.card {
+    background-color: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    padding: 24px;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.grid-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+/* Match Cards */
+.match-card {
+    background-color: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    margin-top: 20px;
+    overflow: hidden;
+}
+
+.match-header {
+    padding: 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.match-header h2 {
+    margin: 0;
+    font-size: 1.2em;
+    font-weight: 400;
+}
+
+.match-date {
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+}
+
+.match-body {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    padding: 20px;
+}
+
+.player-details {
+    text-align: center;
+}
+
+.player-details h3 {
+    font-weight: 500;
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
+.score-details {
+    font-size: 2.5em;
+    font-weight: 500;
+    color: var(--primary-brand);
+}
+
+.separator {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: var(--text-secondary-color);
+}
+
+
+/* Profile */
+.profile-header {
+    text-align: center;
+    margin-bottom: 30px;
+    background-color: var(--surface-color);
+    padding: 30px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+.profile-picture {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 20px;
+    border: 4px solid var(--surface-color);
+    box-shadow: var(--box-shadow);
+}
+
+.profile-header h1 {
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* List Group */
+.list-group {
+    list-style: none;
+    padding: 0;
+    background: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    overflow: hidden;
+}
+
+.list-group-item {
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.list-group-item:last-child {
+    border-bottom: none;
+}
+
+/* Hero section */
+.hero {
+    text-align: center;
+    padding: 80px 20px;
+    background-color: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+.hero h1 {
+    font-size: 3em;
+    font-weight: 400;
+    margin: 0;
+}
+
+.hero p {
+    font-size: 1.2em;
+    color: var(--text-secondary-color);
+    max-width: 600px;
+    margin: 20px auto;
+}
+
+/* Modal */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: var(--surface-color);
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid var(--border-color);
+    width: 80%;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+.modal-header {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h5 {
+    margin: 0;
+    font-weight: 500;
+}
+
+.close {
+    color: var(--text-secondary-color);
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+    color: var(--text-color);
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.modal-body {
+    padding: 16px;
+}
+
+
+/* Footer */
+.footer {
+    text-align: center;
+    padding: 20px 0;
+    margin-top: 40px;
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+}
+
+/* Utility */
+.text-center {
+    text-align: center;
+}
+
+.winning-score {
+    font-weight: bold;
+}
+
+.clickable-row {
+    cursor: pointer;
+}
+
+.clickable-row:hover {
+    background-color: var(--background-color);
+}
+
+.header-with-button {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 30px;
+    margin-bottom: 10px;
+}
+
+.header-with-button h3 {
+    margin: 0;
+}
+
+.header-with-button .btn {
+    width: auto; /* Override the 100% width for buttons */
+    margin-top: 0;
+}
+
+/* Loading Spinner */
+.loader-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+}
+
+.loader {
+    border: 5px solid var(--background-color);
+    border-top: 5px solid var(--primary-color);
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.highlight-row {
+    background-color: rgba(223, 255, 0, 0.1) !important;
+    border-left: 4px solid var(--accent-highlight);
+    font-weight: bold;
+}
+
+/* Guest mobile menu hidden on desktop */
+.guest-mobile-menu {
+    display: none !important;
+}
+
+/* Match View Styles */
+.team-members {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+}
+.team-member {
+    text-align: center;
+}
+.team-member img {
+    width: 60px;
+    height: 60px;
+    margin-bottom: 5px;
+}
+
+/* Group View Styles */
+.group-profile-picture {
+    width: 128px;
+    height: 128px;
+    border-radius: 15px;
+    object-fit: cover;
+}
+.group-header-content {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+.group-header-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+.settings-icon {
+    text-decoration: none;
+    color: var(--text-secondary-color);
+    font-size: 1.8em;
+}
+
+.leaderboard-trend-link {
+    margin-top: 10px;
+    text-align: center;
+}
+
+/* Toasts */
+.toast-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1050;
+    min-width: 300px;
+}
+
+.toast {
+    position: relative;
+    background-color: var(--surface-color);
+    color: var(--on-surface-color);
+    border: none;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    border-radius: 8px;
+    overflow: hidden;
+    max-width: 350px;
+    opacity: 0;
+    transition: opacity 0.15s linear;
+}
+
+.toast.show {
+    opacity: 1;
+}
+
+.toast.hide {
+    display: none;
+}
+
+.toast::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 6px;
+    background-color: var(--primary-color);
+}
+
+.toast-header {
+    background-color: var(--surface-color);
+    color: var(--on-surface-color);
+    border-bottom: none;
+    padding-left: 20px;
+    padding-top: 15px;
+}
+
+.toast-body {
+    padding: 0 20px 15px;
+}
+
+.toast-header .close {
+    margin-right: 5px;
+}
+
+/* Leaderboard Styles */
+.leaderboard-container {
+    font-family: 'Inter', sans-serif;
+}
+
+.leaderboard-header, .leaderboard-row {
+    display: grid;
+    grid-template-columns: 50px 1fr 100px 100px 80px;
+    align-items: center;
+    padding: 10px 15px;
+    gap: 15px;
+}
+
+.leaderboard-header {
+    font-weight: 600;
+    color: var(--on-surface-variant-color);
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 15px;
+}
+
+.leaderboard-row {
+    border-bottom: 1px solid var(--border-color);
+    transition: background-color 0.2s ease-in-out;
+}
+
+.leaderboard-row:last-child {
+    border-bottom: none;
+}
+
+.leaderboard-row:hover {
+    background-color: var(--background-color);
+}
+
+.leaderboard-cell {
+    display: flex;
+    align-items: center;
+}
+
+.player-rank {
+    font-size: 1.2em;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.rank-trend {
+    font-size: 0.8em;
+}
+
+.rank-1 { color: #FFD700; } /* Gold */
+.rank-2 { color: #C0C0C0; } /* Silver */
+.rank-3 { color: #CD7F32; } /* Bronze */
+
+.trend-up { color: var(--success-color); } /* Green */
+.trend-down { color: #EF4444; } /* Red */
+.trend-new { color: #FFC107; } /* Amber */
+
+.player-link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    text-decoration: none;
+    color: inherit;
+}
+
+.player-name {
+    font-weight: 500;
+}
+
+.form-dots {
+    display: flex;
+    gap: 4px;
+}
+
+.form-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+
+.form-dot.win {
+    background-color: #4CAF50; /* Green */
+}
+
+.form-dot.loss {
+    background-color: #E0E0E0; /* Grey */
+}
+
+.highlight-user {
+    border-left: 4px solid var(--primary-color);
+    background-color: #2e7d32 !important;
+    color: #ffffff !important;
+}
+
+.highlight-user .player-link,
+.highlight-user .player-rank,
+.highlight-user .leaderboard-cell {
+    color: #ffffff !important;
+}
+
+/* Latest Games Section */
+.latest-games-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.game-item {
+    display: flex;
+    align-items: center;
+    background-color: var(--surface-color);
+    padding: 15px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    gap: 20px;
+}
+
+.game-date {
+    font-weight: 500;
+    color: var(--text-secondary-color);
+    flex-shrink: 0; /* Prevents date from shrinking */
+    width: 60px; /* Fixed width for alignment */
+}
+
+.game-matchup {
+    flex-grow: 1;
+}
+
+.winner {
+    color: var(--success-color);
+    font-weight: bold;
+}
+
+.game-score {
+    font-size: 1.2em;
+    font-weight: 500;
+    margin-top: 4px;
+}
+
+.game-details {
+    text-align: right;
+    flex-shrink: 0;
+}
+
+.tag {
+    background-color: var(--warning-color);
+    color: var(--text-color);
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 500;
+}
+
+.point-differential {
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+}
+
+#latest-games-feed .game-card {
+    background-color: #FFFFFF;
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    padding: 1rem;
+}
+
+#latest-games-feed .winner {
+    font-weight: bold;
+    color: #10B981;
+}
+
+#latest-games-feed .score-close {
+    color: #0F4C81;
+}
+
+#latest-games-feed .game-card-body {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#latest-games-feed .team {
+    flex: 1;
+    text-align: center;
+}
+
+.badge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 500;
+    display: inline-block;
+    margin-left: 10px;
+}
+
+.badge-close-call {
+    background-color: #ffc107;
+    color: #000000;
+}
+
+/* Mobile Formatting */
+@media screen and (max-width: 768px) {
+    .game-item {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .game-date {
+        width: auto;
+        margin-bottom: 10px;
+        font-size: 0.9em;
+    }
+
+    .game-details {
+        display: none; /* Hide on mobile as requested */
+    }
+
+    .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.rivalry-check-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+.rivalry-player-select {
+    width: 45%;
+}
+.rivalry-vs {
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+@media (max-width: 768px) {
+    body {
+        overflow-x: hidden;
+    }
+    .leaderboard-header {
+        display: none;
+    }
+
+    .leaderboard-cell[data-label="Form"],
+    .leaderboard-cell[data-label="Games"] {
+        display: none;
+    }
+
+    .leaderboard-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        grid-template-columns: none; /* Override grid layout */
+        padding: 16px 8px;
+    }
+
+    .leaderboard-row .profile-picture-thumbnail {
+        width: 32px;
+        height: 32px;
+        flex-shrink: 0;
+        margin-right: 15px;
+    }
+
+    .player-name {
+        font-size: 0.9rem;
+    }
+
+    .leaderboard-cell[data-label="Player"] {
+        flex-grow: 1;
+    }
+
+    .leaderboard-cell[data-label="Avg. Score"] {
+        font-weight: bold;
+        font-size: 1.1em;
+    }
+  .grid-container {
+    grid-template-columns: 1fr;
+  }
+  .group-header-actions {
+    flex-wrap: wrap;
+  }
+  .group-header-actions > .btn {
+    width: 100%;
+    margin-top: 10px;
+  }
+}
 /* Mobile Dashboard Polish */
 @media (max-width: 768px) {
     .container {


### PR DESCRIPTION
The application was rendering as raw HTML because the main stylesheet `pickaladder/static/style.css` was missing its top half (base styles) and had potential syntax issues. I restored the missing styles from a previous commit, verified brace balance, and ensured no conflict markers were present. Visual verification confirms the application is now correctly styled.

Fixes #611

---
*PR created automatically by Jules for task [18169167909832332625](https://jules.google.com/task/18169167909832332625) started by @brewmarsh*