### PR TITLE
Condense Team Leaderboard Stats

### DIFF
--- a/pickaladder/static/mobile.css
+++ b/pickaladder/static/mobile.css
@@ -160,7 +160,8 @@
         border-radius: var(--border-radius);
     }
 
-    .leaderboard-cell[data-label="Player"] {
+    .leaderboard-cell[data-label="Player"],
+    .leaderboard-cell[data-label="Team"] {
         grid-area: player;
         font-size: 1.2em;
         margin-bottom: 15px;
@@ -168,6 +169,7 @@
 
     .leaderboard-cell[data-label="Rank"],
     .leaderboard-cell[data-label="Avg. Score"],
+    .leaderboard-cell[data-label="Stats"],
     .leaderboard-cell[data-label="Form"],
     .leaderboard-cell[data-label="Games"] {
         display: flex;
@@ -196,5 +198,9 @@
         border: 2px solid var(--primary-color);
         border-left: none; /* Override desktop style */
         background-color: #E8F5E9; /* A light green */
+    }
+
+    .team-leaderboard .leaderboard-row {
+        grid-template-columns: 1fr;
     }
 }

--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -583,6 +583,10 @@ input[type="submit"], .btn {
     text-align: center;
 }
 
+.text-muted {
+    color: var(--text-secondary-color);
+}
+
 .winning-score {
     font-weight: bold;
 }
@@ -854,6 +858,11 @@ input[type="submit"], .btn {
     flex-direction: row;
     gap: 8px;
     justify-content: flex-start;
+}
+
+.team-leaderboard .leaderboard-header,
+.team-leaderboard .leaderboard-row {
+    grid-template-columns: 50px 1fr 150px 80px;
 }
 
 /* Latest Games Section */

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -100,12 +100,11 @@
                 </div>
 
                 <div id="teams" class="tab-content" style="display: none;">
-                    <div class="leaderboard-container">
+                    <div class="leaderboard-container team-leaderboard">
                         <div class="leaderboard-header">
                             <div class="leaderboard-cell">Rank</div>
                             <div class="leaderboard-cell">Team</div>
-                            <div class="leaderboard-cell">Win %</div>
-                            <div class="leaderboard-cell">Record</div>
+                            <div class="leaderboard-cell">Stats</div>
                             <div class="leaderboard-cell">Games</div>
                         </div>
                         <div class="leaderboard-body">
@@ -131,8 +130,10 @@
                                         <span class="team-name">{{ entry.team.name }}</span>
                                     </div>
                                 </div>
-                                <div class="leaderboard-cell" data-label="Win %">{{ "%.1f"|format(entry.stats.win_percentage) }}%</div>
-                                <div class="leaderboard-cell" data-label="Record">{{ entry.stats.wins }}-{{ entry.stats.losses }}</div>
+                                <div class="leaderboard-cell" data-label="Stats">
+                                    <span style="font-weight: 500;">{{ entry.stats.wins }} - {{ entry.stats.losses }}</span>
+                                    <span class="text-muted" style="font-size: 0.9em; margin-left: 5px;">({{ "%.1f"|format(entry.stats.win_percentage) }}%)</span>
+                                </div>
                                 <div class="leaderboard-cell" data-label="Games">{{ entry.stats.games }}</div>
                             </div>
                             {% else %}


### PR DESCRIPTION
This change condenses the Team Leaderboard in `pickaladder/templates/group.html` to save vertical space.

Key changes:
1.  **Template Update**: In `group.html`, the separate 'Win %' and 'Record' columns are replaced with a single 'Stats' column. The display logic now combines these into one line: `{{ wins }} - {{ losses }} ({{ win_percentage }}%)`.
2.  **Visual Styling**:
    *   The Win-Loss record is bolded (`font-weight: 500`).
    *   The percentage is styled with a new `.text-muted` class and smaller font size.
3.  **CSS Improvements**:
    *   Added a `.text-muted` utility class to `style.css`.
    *   Defined a specific 4-column grid layout for `.team-leaderboard` to replace the default 5-column layout.
    *   Updated `mobile.css` to ensure the new 'Stats' and 'Team' labels are correctly handled in the mobile stacked view.

Verified on both desktop and mobile views. All tests passed.

Fixes #618

---
*PR created automatically by Jules for task [13400828727833805967](https://jules.google.com/task/13400828727833805967) started by @brewmarsh*