### PR TITLE
Upgrade Deployment and Documentation to Docker Compose V2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
             # Login to GitHub Container Registry
             docker login ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
 
-            # Set environment variables for docker-compose and the deployment script
+            # Set environment variables for docker compose and the deployment script
             export IMAGE_TAG=ghcr.io/${{ github.repository }}:${{ github.sha }}
             export SECRET_KEY='${{ secrets.SECRET_KEY }}'
             export MAIL_SERVER='${{ secrets.MAIL_SERVER }}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,11 @@ The Flask application is organized into blueprints. The main application is conf
 4.  **Clean the Docker environment:**
     This will stop containers and remove all volumes (including the database).
     ```bash
-    docker-compose down -v
+    docker compose down -v
     ```
 
 ### Troubleshooting
-* **Database Issues:** If you encounter issues with the database, the cleanest way to reset is to run `docker-compose down -v` and then `make up`.
+* **Database Issues:** If you encounter issues with the database, the cleanest way to reset is to run `docker compose down -v` and then `make up`.
 * **Docker Errors:** If you see `permission denied` or `service "web" is not running`, try running the `make` commands with `sudo`.
 * **Docker Hub Rate Limit:** A `429 Too Many Requests` error means Docker Hub is rate-limiting anonymous pulls. There is no immediate workaround besides waiting.
 

--- a/agents.md
+++ b/agents.md
@@ -27,7 +27,7 @@ When getting started, it's helpful to review these key files to understand the a
 
 *   **To build and start the application:** `make up`
 *   **To run backend tests:** `make test`. **Important:** The application environment must be running before you can run the tests. Always run `make up` before running `make test`.
-*   **To clean the Docker environment:** `docker-compose down -v`
+*   **To clean the Docker environment:** `docker compose down -v`
 
 *For more commands, see the `Makefile` and `README.md`.*
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -8,7 +8,7 @@ The pickaladder application is a web-based application that allows users to crea
 
 ## 2. System Architecture
 
-The application is a monolithic web application built with Flask and PostgreSQL. It is containerized with Docker and deployed with docker-compose.
+The application is a monolithic web application built with Flask and PostgreSQL. It is containerized with Docker and deployed with docker compose.
 
 ### 2.1. Application Architecture
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -35,7 +35,7 @@ This document outlines the requirements for the pickaladder application.
 
 ### Architecture
 *   **Monolithic Application:** The application is a monolithic web application built with Flask and PostgreSQL.
-*   **Containerized:** The application is containerized with Docker and deployed with docker-compose.
+*   **Containerized:** The application is containerized with Docker and deployed with docker compose.
 *   **Blueprint-based:** The Flask application is organized using a blueprint-based structure.
 
 ### Database

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -77,7 +77,7 @@ done
 
 # 1. Try to take down the project gracefully
 # We ignore errors here because the state might be corrupted (hence the KeyError)
-docker-compose -f docker-compose.prod.yml down --remove-orphans || true
+docker compose -f docker-compose.prod.yml down --remove-orphans || true
 
 # 2. Force remove containers by label (matches any container in the project)
 # This finds all containers belonging to 'picka-server' project
@@ -148,7 +148,7 @@ else
     # 2. Start the web and nginx services. The new Nginx entrypoint will
     # automatically wait for the web service to be ready.
     echo ">>> Starting web and nginx with dummy certificate..."
-    if ! docker-compose -f docker-compose.prod.yml up -d web nginx; then
+    if ! docker compose -f docker-compose.prod.yml up -d web nginx; then
         echo "ERROR: Failed to start web and nginx."
         echo ">>> Diagnostic info:"
         echo "--- docker ps -a ---"
@@ -200,7 +200,7 @@ else
     # We remove the dummy files before certbot runs.
     echo ">>> Requesting real certificate from Let's Encrypt..."
     sudo rm -rf $CERT_DIR
-    docker-compose -f docker-compose.prod.yml run --name picka-certbot-init --rm --entrypoint certbot certbot certonly --webroot \
+    docker compose -f docker-compose.prod.yml run --name picka-certbot-init --rm --entrypoint certbot certbot certonly --webroot \
         --webroot-path /var/www/certbot \
         --email $EMAIL \
         --agree-tos \
@@ -211,11 +211,11 @@ else
     # 4. Stop the Nginx container that was using the dummy cert.
     # The next step will bring everything up with the real cert.
     echo ">>> Shutting down Nginx..."
-    docker-compose -f docker-compose.prod.yml down
+    docker compose -f docker-compose.prod.yml down
 fi
 
 # 5. Start or restart all services with the final configuration and real certificate.
 echo ">>> Starting all services for production..."
-docker-compose -f docker-compose.prod.yml up --build -d --remove-orphans
+docker compose -f docker-compose.prod.yml up --build -d --remove-orphans
 
 echo ">>> Deployment script finished successfully."

--- a/verify_production.sh
+++ b/verify_production.sh
@@ -46,7 +46,7 @@ echo -e "\n>>> 5. Testing Connectivity (Nginx -> Web)..."
 if docker ps --format '{{.Names}}' | grep -q "^${NGINX_CONTAINER}$"; then
     # Check if netcat is available
     if docker exec "$NGINX_CONTAINER" which nc > /dev/null 2>&1; then
-        # In docker-compose, the host is the service name 'web'.
+        # In docker compose, the host is the service name 'web'.
         if docker exec "$NGINX_CONTAINER" nc -z -v web 27272; then
             echo " [OK] Nginx can reach 'web' on port 27272."
         else


### PR DESCRIPTION
Upgraded the project to use Docker Compose V2 by replacing the deprecated `docker-compose` command with `docker compose`. This includes updates to the deployment script (`init-letsencrypt.sh`), documentation files, and various comments throughout the codebase. Filenames were preserved where appropriate.

Fixes #621

---
*PR created automatically by Jules for task [3787753408563264450](https://jules.google.com/task/3787753408563264450) started by @brewmarsh*