### PR TITLE
Switch Agent Readiness check to Diff Mode

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -36,7 +36,7 @@ jobs:
           # Fallback to 'main' if not in a PR
           TARGET_BRANCH="origin/${{ github.base_ref || 'main' }}"
           echo "Running Agent Scorecard against $TARGET_BRANCH..."
-          agent-score score --diff $TARGET_BRANCH --format markdown > readiness_report.md
+          agent-score score --diff $TARGET_BRANCH --report readiness_report.md
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Switched the Agent Readiness check in GitHub Actions to "Diff Mode". This involves updating the checkout depth and the scorecard execution script to compare against the PR's base branch.

Fixes #632

---
*PR created automatically by Jules for task [3778446072926610304](https://jules.google.com/task/3778446072926610304) started by @brewmarsh*