### PR TITLE
Fix Ghost User Names to prioritize Name field

### DIFF
--- a/pickaladder/user/utils.py
+++ b/pickaladder/user/utils.py
@@ -132,17 +132,22 @@ def smart_display_name(user: dict) -> str:
     """Return a smart display name for a user.
 
     If the user is a ghost user (username starts with 'ghost_'):
-    - If they have an email, return a masked version of it.
-    - If they have no name, return 'Pending Invite'.
+    - If they have a name, return it.
+    - If they have an email but no name, return a masked version of it.
+    - If they have no name and no email, return 'Pending Invite'.
     Otherwise, return the username.
     """
     username = user.get("username", "")
     if username.startswith("ghost_"):
+        name = user.get("name")
+        if name:
+            return name
+
         email = user.get("email")
         if email:
             return mask_email(email)
-        if not user.get("name"):
-            return "Pending Invite"
+
+        return "Pending Invite"
 
     return username
 

--- a/tests/test_ghost_display.py
+++ b/tests/test_ghost_display.py
@@ -19,7 +19,8 @@ class TestGhostDisplay(unittest.TestCase):
             "email": "march@gmail.com",
             "name": "John Doe",
         }
-        self.assertEqual(smart_display_name(user), "m...h@gmail.com")
+        # Prioritize name over masked email
+        self.assertEqual(smart_display_name(user), "John Doe")
 
     def test_smart_display_name_ghost_no_email_no_name(self):
         user = {"username": "ghost_ceec6a"}
@@ -27,9 +28,16 @@ class TestGhostDisplay(unittest.TestCase):
 
     def test_smart_display_name_ghost_no_email_with_name(self):
         user = {"username": "ghost_ceec6a", "name": "John Doe"}
-        # Based on literal instructions: "Otherwise, show the username"
-        # Since it's a ghost, but no email and HAS a name, it doesn't match rule 1 or 2.
-        self.assertEqual(smart_display_name(user), "ghost_ceec6a")
+        # Should return name if present
+        self.assertEqual(smart_display_name(user), "John Doe")
+
+    def test_smart_display_name_ghost_with_email_no_name(self):
+        user = {
+            "username": "ghost_ceec6a",
+            "email": "march@gmail.com",
+        }
+        # Fallback to masked email if name is missing
+        self.assertEqual(smart_display_name(user), "m...h@gmail.com")
 
     def test_smart_display_name_regular_user(self):
         user = {"username": "jdoe", "email": "jdoe@example.com", "name": "John Doe"}


### PR DESCRIPTION
Updated `smart_display_name` in `pickaladder/user/utils.py` to prioritize the `name` field for ghost users. Previously, it would show a masked email even if a name was present. Now it checks for `name` first, then `email` (masked), and finally defaults to 'Pending Invite'. Updated `tests/test_ghost_display.py` to verify this behavior.

Fixes #633

---
*PR created automatically by Jules for task [17836341846660531534](https://jules.google.com/task/17836341846660531534) started by @brewmarsh*