### PR TITLE
Update Dashboard with Team Names and Bold Styling

### DIFF
--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -58,11 +58,26 @@
                                         {% if in_team1 %}
                                             {% set partner = match.player1[1] if match.player1[0].id == user.uid else match.player1[0] %}
                                             {% set opponents = match.player2 %}
+                                            {% set my_team_name = match.team1_name %}
+                                            {% set opponent_team_name = match.team2_name %}
                                         {% else %}
                                             {% set partner = match.player2[1] if match.player2[0].id == user.uid else match.player2[0] %}
                                             {% set opponents = match.player1 %}
+                                            {% set my_team_name = match.team2_name %}
+                                            {% set opponent_team_name = match.team1_name %}
                                         {% endif %}
-                                        (You & {{ partner.username }}) vs ({{ opponents[0].username }} & {{ opponents[1].username }})
+
+                                        {% if my_team_name %}
+                                            <strong>{{ my_team_name }}</strong>
+                                        {% else %}
+                                            (You & {{ partner.username }})
+                                        {% endif %}
+                                        vs
+                                        {% if opponent_team_name %}
+                                            <strong>{{ opponent_team_name }}</strong>
+                                        {% else %}
+                                            ({{ opponents[0].username }} & {{ opponents[1].username }})
+                                        {% endif %}
                                     {% else %}
                                         {% set is_p1 = match.player1.id == user.uid %}
                                         {% set opponent = match.player2 if is_p1 else match.player1 %}

--- a/pickaladder/user/utils.py
+++ b/pickaladder/user/utils.py
@@ -746,6 +746,7 @@ class UserService:
         """Format matches for the API dashboard view."""
         # Batch fetch user data for all players in the recent matches
         player_refs = set()
+        team_ids = set()
         for match_doc in matches_docs:
             match = match_doc.to_dict()
             if match is None:
@@ -759,10 +760,22 @@ class UserService:
             for ref in match.get("team2", []):
                 player_refs.add(ref)
 
+            if match.get("matchType") == "doubles":
+                if t1_id := match.get("team1Id"):
+                    team_ids.add(t1_id)
+                if t2_id := match.get("team2Id"):
+                    team_ids.add(t2_id)
+
         users_map = {}
         if player_refs:
             user_docs = db.get_all(list(player_refs))
             users_map = {doc.id: doc.to_dict() for doc in user_docs if doc.exists}
+
+        teams_map = {}
+        if team_ids:
+            team_refs = [db.collection("teams").document(tid) for tid in team_ids]
+            team_docs = db.get_all(team_refs)
+            teams_map = {doc.id: doc.to_dict() for doc in team_docs if doc.exists}
 
         matches_data = []
         for match_doc in matches_docs:
@@ -812,6 +825,18 @@ class UserService:
                     match["player2Ref"], users_map
                 )
 
+            team1_name = None
+            team2_name = None
+            if match.get("matchType") == "doubles":
+                if t1_id := match.get("team1Id"):
+                    team1_data = teams_map.get(t1_id)
+                    if team1_data:
+                        team1_name = team1_data.get("name")
+                if t2_id := match.get("team2Id"):
+                    team2_data = teams_map.get(t2_id)
+                    if team2_data:
+                        team2_name = team2_data.get("name")
+
             matches_data.append(
                 {
                     "id": match_doc.id,
@@ -824,6 +849,8 @@ class UserService:
                     "is_group_match": bool(match.get("groupId")),
                     "match_type": match.get("matchType", "singles"),
                     "user_result": user_result,
+                    "team1_name": team1_name,
+                    "team2_name": team2_name,
                 }
             )
         return matches_data


### PR DESCRIPTION
Updated the user dashboard's 'Recent Activity' section to prioritize displaying team names for doubles matches. The backend now fetches team names from the Firestore `teams` collection and includes them in the match data passed to the template. The template has been updated to show these names in bold, while maintaining the user-centric "You & Partner" fallback logic if team names are not set.

Fixes #653

---
*PR created automatically by Jules for task [16493541173581510194](https://jules.google.com/task/16493541173581510194) started by @brewmarsh*