### PR TITLE
Update Tournament Invite Player Form

### DIFF
--- a/pickaladder/templates/tournament/view.html
+++ b/pickaladder/templates/tournament/view.html
@@ -144,10 +144,18 @@
                     <form method="POST">
                         {{ invite_form.csrf_token }}
                         <div class="form-group">
-                            {{ invite_form.player.label(class="form-label") }}
-                            {{ invite_form.player(class="form-input") }}
+                            <label for="player" class="form-label">Player</label>
+                            <select name="player" id="player" class="form-input" {% if not invitable_users %}disabled{% endif %}>
+                                {% if invitable_users %}
+                                    {% for user in invitable_users %}
+                                        <option value="{{ user.id }}">{{ user.username }}</option>
+                                    {% endfor %}
+                                {% else %}
+                                    <option disabled selected>No more friends to invite</option>
+                                {% endif %}
+                            </select>
                         </div>
-                        <button type="submit" name="player" class="btn btn-primary">Invite</button>
+                        <button type="submit" name="player" class="btn btn-primary" {% if not invitable_users %}disabled{% endif %}>Invite</button>
                     </form>
                 </div>
             </div>

--- a/pickaladder/tournament/routes.py
+++ b/pickaladder/tournament/routes.py
@@ -182,6 +182,7 @@ def view_tournament(tournament_id: str) -> Any:
         standings=standings,
         podium=podium,
         invite_form=invite_form,
+        invitable_users=eligible_friends,
         is_owner=(tournament_data.get("ownerRef").id == g.user["uid"]),
     )
 


### PR DESCRIPTION
Updated the 'Invite Player' form in the tournament view. The form now correctly populates a dropdown with friends not already in the tournament, formats the options as requested (username for display, ID for value), and handles the case where there are no more friends to invite by disabling the form and showing a helpful message. Verified with unit tests, e2e tests, and frontend screenshots.

Fixes #669

---
*PR created automatically by Jules for task [7046425767292976611](https://jules.google.com/task/7046425767292976611) started by @brewmarsh*