### PR TITLE
Add Dedicated Tournament Invite Route

### DIFF
--- a/pickaladder/templates/tournament/view.html
+++ b/pickaladder/templates/tournament/view.html
@@ -141,13 +141,18 @@
                     <h4 style="margin: 0;">Invite Player</h4>
                 </div>
                 <div class="card-body" style="padding: 0;">
-                    <form method="POST">
-                        {{ invite_form.csrf_token }}
+                    <form action="{{ url_for('tournament.invite_player', tournament_id=tournament.id) }}" method="POST">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <div class="form-group">
-                            {{ invite_form.player.label(class="form-label") }}
-                            {{ invite_form.player(class="form-input") }}
+                            <label for="user_id" class="form-label">Player</label>
+                            <select name="user_id" id="user_id" class="form-input" required>
+                                <option value="" disabled selected>Select a player</option>
+                                {% for user in invitable_users %}
+                                    <option value="{{ user.id }}">{{ user|smart_display_name }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
-                        <button type="submit" name="player" class="btn btn-primary">Invite</button>
+                        <button type="submit" class="btn btn-primary">Invite</button>
                     </form>
                 </div>
             </div>

--- a/pickaladder/tournament/routes.py
+++ b/pickaladder/tournament/routes.py
@@ -124,15 +124,21 @@ def view_tournament(tournament_id: str) -> Any:
     participants = []
     participant_objs = tournament_data.get("participants", [])
     if participant_objs:
-        user_refs = [obj["userRef"] for obj in participant_objs]
+        user_refs = [
+            obj["userRef"]
+            if "userRef" in obj
+            else db.collection("users").document(obj["user_id"])
+            for obj in participant_objs
+            if "userRef" in obj or "user_id" in obj
+        ]
         user_docs = db.get_all(user_refs)
         users_map = {
             doc.id: {**doc.to_dict(), "id": doc.id} for doc in user_docs if doc.exists
         }
 
         for obj in participant_objs:
-            user_id = obj["userRef"].id
-            if user_id in users_map:
+            user_id = obj["userRef"].id if "userRef" in obj else obj.get("user_id")
+            if user_id and user_id in users_map:
                 user_data = users_map[user_id]
                 participants.append(
                     {
@@ -182,7 +188,10 @@ def view_tournament(tournament_id: str) -> Any:
         invitable_map[u["id"]] = u
 
     current_uid = g.user["uid"]
-    participant_ids = {obj["userRef"].id for obj in participant_objs}
+    participant_ids = {
+        obj["userRef"].id if "userRef" in obj else obj.get("user_id")
+        for obj in participant_objs
+    }
 
     invitable_users = [
         u
@@ -194,24 +203,6 @@ def view_tournament(tournament_id: str) -> Any:
         (u["id"], smart_display_name(u)) for u in invitable_users
     ]
 
-    if invite_form.validate_on_submit() and "player" in request.form:
-        invited_user_id = invite_form.player.data
-        invited_user_ref = db.collection("users").document(invited_user_id)
-
-        try:
-            tournament_ref.update(
-                {
-                    "participants": firestore.ArrayUnion(
-                        [{"userRef": invited_user_ref, "status": "pending"}]
-                    ),
-                    "participant_ids": firestore.ArrayUnion([invited_user_id]),
-                }
-            )
-            flash("Player invited successfully.", "success")
-            return redirect(url_for(".view_tournament", tournament_id=tournament_id))
-        except Exception as e:
-            flash(f"An unexpected error occurred: {e}", "danger")
-
     return render_template(
         "tournament/view.html",
         tournament=tournament_data,
@@ -222,6 +213,65 @@ def view_tournament(tournament_id: str) -> Any:
         invitable_users=invitable_users,
         is_owner=(tournament_data.get("ownerRef").id == g.user["uid"]),
     )
+
+
+@bp.route("/<string:tournament_id>/invite", methods=["POST"])
+@login_required
+def invite_player(tournament_id: str) -> Any:
+    """Invite a player to the tournament."""
+    db = firestore.client()
+    tournament_ref = db.collection("tournaments").document(tournament_id)
+    tournament_doc = tournament_ref.get()
+
+    if not tournament_doc.exists:
+        flash("Tournament not found.", "danger")
+        return redirect(url_for(".list_tournaments"))
+
+    tournament_data = tournament_doc.to_dict()
+    if not tournament_data:
+        flash("Tournament data is empty.", "danger")
+        return redirect(url_for(".list_tournaments"))
+
+    # Security check: Ensure the current user is the organizer_id
+    organizer_id = tournament_data.get("organizer_id")
+    # Fallback to ownerRef if organizer_id is not set
+    if not organizer_id and "ownerRef" in tournament_data:
+        organizer_id = tournament_data["ownerRef"].id
+
+    if organizer_id != g.user["uid"]:
+        flash("Only the organizer can invite players.", "danger")
+        return redirect(url_for(".view_tournament", tournament_id=tournament_id))
+
+    user_id = request.form.get("user_id")
+    if not user_id:
+        flash("No user selected.", "danger")
+        return redirect(url_for(".view_tournament", tournament_id=tournament_id))
+
+    # Fetch invited user for the flash message
+    invited_user_doc = db.collection("users").document(user_id).get()
+    if not invited_user_doc.exists:
+        flash("User not found.", "danger")
+        return redirect(url_for(".view_tournament", tournament_id=tournament_id))
+
+    invited_user_data = invited_user_doc.to_dict() or {}
+    username = (
+        invited_user_data.get("username") or invited_user_data.get("name") or "User"
+    )
+
+    try:
+        tournament_ref.update(
+            {
+                "participants": firestore.ArrayUnion(
+                    [{"user_id": user_id, "status": "pending", "team_name": None}]
+                ),
+                "participant_ids": firestore.ArrayUnion([user_id]),
+            }
+        )
+        flash(f"Invite sent to {username}", "success")
+    except Exception as e:
+        flash(f"An unexpected error occurred: {e}", "danger")
+
+    return redirect(url_for(".view_tournament", tournament_id=tournament_id))
 
 
 @bp.route("/<string:tournament_id>/complete", methods=["POST"])
@@ -303,7 +353,8 @@ def join_tournament(tournament_id: str) -> Any:
 
     updated = False
     for p in participants:
-        if p["userRef"].id == g.user["uid"] and p["status"] == "pending":
+        p_user_id = p["userRef"].id if "userRef" in p else p.get("user_id")
+        if p_user_id == g.user["uid"] and p["status"] == "pending":
             p["status"] = "accepted"
             updated = True
             break

--- a/tests/e2e/test_tournament.py
+++ b/tests/e2e/test_tournament.py
@@ -57,7 +57,7 @@ def test_tournament_flow(
 
     page.reload()
     page.screenshot(path="/home/jules/verification/tournament_invite.png")
-    expect(page.locator("select[name='player']")).to_contain_text("friend_user")
+    expect(page.locator("select[name='user_id']")).to_contain_text("friend_user")
 
     # 3. Check Directions button
     directions_btn = page.locator("text=Directions")


### PR DESCRIPTION
Implemented a dedicated POST route for inviting players to tournaments, as requested. The solution includes security validation to ensure only the organizer can invite players and updates the Firestore document with the specified participant object structure. To maintain backward compatibility, I also updated the tournament view and join logic to support both legacy (userRef) and new (user_id) participant formats. E2E tests were updated and verified to ensure the tournament flow remains functional.

Fixes #675

---
*PR created automatically by Jules for task [7254068108990145718](https://jules.google.com/task/7254068108990145718) started by @brewmarsh*