### PR TITLE
Fix test regressions from Service Layer refactor

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+mock-firestore==0.11.0
+pytest==8.3.4
+pytest-flask==1.3.0

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -82,10 +82,6 @@ class TournamentRoutesFirebaseTestCase(unittest.TestCase):
 
         patchers = {
             "init_app": patch("firebase_admin.initialize_app"),
-            "firestore_routes": patch(
-                "pickaladder.tournament.routes.firestore",
-                new=self.mock_firestore_module,
-            ),
             "firestore_services": patch(
                 "pickaladder.tournament.services.firestore",
                 new=self.mock_firestore_module,

--- a/tests/test_tournament_invites.py
+++ b/tests/test_tournament_invites.py
@@ -23,10 +23,6 @@ class TournamentInvitesTestCase(unittest.TestCase):
 
         patchers = {
             "init_app": patch("firebase_admin.initialize_app"),
-            "firestore_routes": patch(
-                "pickaladder.tournament.routes.firestore",
-                new=self.mock_firestore_service,
-            ),
             "firestore_services": patch(
                 "pickaladder.tournament.services.firestore",
                 new=self.mock_firestore_service,
@@ -144,7 +140,7 @@ class TournamentInvitesTestCase(unittest.TestCase):
         # need to patch if it doesn't work well with MagicMocks.
 
         with patch(
-            "pickaladder.tournament.routes.firestore.transactional"
+            "pickaladder.tournament.services.firestore.transactional"
         ) as mock_trans_decorator:
             # Make the decorator just return the function
             mock_trans_decorator.side_effect = lambda x: x
@@ -189,7 +185,7 @@ class TournamentInvitesTestCase(unittest.TestCase):
         mock_tournament_ref.get.return_value = mock_snapshot
 
         with patch(
-            "pickaladder.tournament.routes.firestore.transactional"
+            "pickaladder.tournament.services.firestore.transactional"
         ) as mock_trans_decorator:
             mock_trans_decorator.side_effect = lambda x: x
 


### PR DESCRIPTION
This PR fixes the test suite regressions that occurred after moving business logic from `routes.py` to `services.py`. 

Key changes:
1. Added `mock-firestore` to a new `requirements-test.txt` file.
2. Updated `tests/test_tournament_invites.py` and `tests/test_tournament.py` to point their `firestore` patches to `pickaladder.tournament.services.firestore`.
3. Adjusted the `@firestore.transactional` decorator patches in `tests/test_tournament_invites.py` to use the new service-layer target.

All 82 tests in the suite are now passing.

Fixes #708

---
*PR created automatically by Jules for task [14074262901900791067](https://jules.google.com/task/14074262901900791067) started by @brewmarsh*