### PR TITLE
Admin Menu Cleanup: Remove Generator Tools

### DIFF
--- a/pickaladder/templates/admin.html
+++ b/pickaladder/templates/admin.html
@@ -13,22 +13,6 @@
             </button>
         </div>
         <div class="card">
-            <h3>Generate Users</h3>
-            <p>This will generate 10 random users.</p>
-            <form action="{{ url_for('admin.generate_users') }}" method="post">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="btn btn-primary">Generate Users</button>
-            </form>
-        </div>
-        <div class="card">
-            <h3>Generate Matches</h3>
-            <p>This will generate 10 random matches between friends.</p>
-            <form action="{{ url_for('admin.generate_matches') }}" method="post">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="btn btn-primary">Generate Matches</button>
-            </form>
-        </div>
-        <div class="card">
             <h3>Enforce Email Verification</h3>
             <p>
                 Current status:


### PR DESCRIPTION
This change removes the deprecated "Generate Users" and "Generate Matches" tools from the Admin Dashboard in `pickaladder/templates/admin.html`. These tools were used for testing and are no longer needed in the production dashboard. The removal was verified with logic tests and visual screenshots using Playwright, ensuring the grid layout remains intact.

Fixes #755

---
*PR created automatically by Jules for task [2119708163838223030](https://jules.google.com/task/2119708163838223030) started by @brewmarsh*