### PR TITLE
Revert user avatar style to avataaars

### DIFF
--- a/pickaladder/user/models.py
+++ b/pickaladder/user/models.py
@@ -25,6 +25,6 @@ class User(UserDict, UserMixin):
         if profile_pic:
             return str(profile_pic)
 
-        # Fallback to UI Avatars
-        name = self.get("name") or self.get("username") or "User"
-        return f"https://ui-avatars.com/api/?name={name}&background=random&color=fff"
+        # Fallback to DiceBear Avatars (avataaars style)
+        seed = self.get("username") or self.get("email") or "User"
+        return f"https://api.dicebear.com/9.x/avataaars/svg?seed={seed}"


### PR DESCRIPTION
This change updates the user avatar generation logic to use the DiceBear 'avataaars' style instead of the previous 'initials' style (which was actually using ui-avatars.com). It ensures that avatars are more visual while remaining deterministic by using the username or email as the seed.

Fixes #764

---
*PR created automatically by Jules for task [11652173903881800036](https://jules.google.com/task/11652173903881800036) started by @brewmarsh*