### PR TITLE
Improve Community Hub UI and Navigation

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -1326,6 +1326,18 @@ input[type="submit"], .btn {
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
 }
 
+.card-action:hover {
+    background-color: var(--background-color);
+    cursor: pointer;
+}
+
+.friend-card-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    width: 100%;
+}
+
 .friend-avatar {
     width: 100px;
     height: 100px;

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -1,11 +1,9 @@
 {% extends "layout.html" %}
 {% block title %}Community Hub{% endblock %}
 {% block content %}
-    <div class="page-header">
+    <div class="page-header header-with-button">
         <h1>Community Hub</h1>
-        <div>
-            <button id="invite-friend-btn" class="btn" data-csrf="{{ csrf_token() }}">Invite a Friend</button>
-        </div>
+        <button id="invite-friend-btn" class="btn" data-csrf="{{ csrf_token() }}">Invite a Friend</button>
     </div>
     <div id="invite-success-message" class="alert alert-success" style="display: none;"></div>
 
@@ -129,15 +127,20 @@
         {% if friends %}
             <div class="friend-grid">
                 {% for friend in friends %}
-                    <div class="friend-card">
-                        <div class="friend-card-content">
-                            <img src="{{ friend | avatar_url }}" alt="{{ friend.username }}" class="friend-avatar">
-                            <h3 class="friend-name">{{ friend.username }}</h3>
-                            <div class="friend-rating">
-                                <span class="star-icon">⭐</span>
-                                <span class="dupr-value">{{ friend.duprRating or 'N/A' }}</span>
+                    <div class="friend-card card-action">
+                        <a href="{{ url_for('user.view_user', user_id=friend.id) }}" class="friend-card-link">
+                            <div class="friend-card-content">
+                                <img src="{{ friend | avatar_url }}" alt="{{ friend.username }}" class="friend-avatar">
+                                <h3 class="friend-name">{{ friend.name or friend.username }}</h3>
+                                {% if friend.name and friend.name != friend.username %}
+                                    <p class="text-muted" style="margin-top: -5px; font-size: 0.85em;">@{{ friend.username }}</p>
+                                {% endif %}
+                                <div class="friend-rating">
+                                    <span class="star-icon">⭐</span>
+                                    <span class="dupr-value">{{ friend.duprRating or 'N/A' }}</span>
+                                </div>
                             </div>
-                        </div>
+                        </a>
                         <div class="friend-card-actions">
                             <a href="{{ url_for('match.record_match', opponent=friend.id) }}" class="btn btn-primary challenge-btn">Challenge</a>
                         </div>
@@ -152,36 +155,30 @@
     <div class="discover-section" style="margin-bottom: 40px;">
         <h3>Discover Players</h3>
         {% if all_users %}
-            <div class="table-container">
-                <table class="table responsive-table">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th>Username</th>
-                            <th>Name</th>
-                            <th>DUPR Rating</th>
-                            <th style="text-align: right;">Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for user_data in all_users %}
-                            <tr>
-                                <td data-label="Avatar">
-                                    <img src="{{ user_data | avatar_url }}" alt="Profile Picture" class="profile-picture-thumbnail avatar" onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
-                                </td>
-                                <td data-label="Username"><a href="{{ url_for('user.view_user', user_id=user_data.id) }}">{{ user_data.username }}</a></td>
-                                <td data-label="Name">{{ user_data.name }}</td>
-                                <td data-label="DUPR Rating">{{ user_data.duprRating or 'N/A' }}</td>
-                                <td data-label="Actions" class="actions-cell" style="text-align: right;">
-                                    <form method="post" action="{{ url_for('user.send_friend_request', friend_id=user_data.id) }}" style="display: inline;">
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button type="submit" class="btn add-friend-btn">Add Friend</button>
-                                    </form>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+            <div class="friend-grid">
+                {% for user_data in all_users %}
+                    <div class="friend-card card-action">
+                        <a href="{{ url_for('user.view_user', user_id=user_data.id) }}" class="friend-card-link">
+                            <div class="friend-card-content">
+                                <img src="{{ user_data | avatar_url }}" alt="{{ user_data.username }}" class="friend-avatar">
+                                <h3 class="friend-name">{{ user_data.name or user_data.username }}</h3>
+                                {% if user_data.name and user_data.name != user_data.username %}
+                                    <p class="text-muted" style="margin-top: -5px; font-size: 0.85em;">@{{ user_data.username }}</p>
+                                {% endif %}
+                                <div class="friend-rating">
+                                    <span class="star-icon">⭐</span>
+                                    <span class="dupr-value">{{ user_data.duprRating or 'N/A' }}</span>
+                                </div>
+                            </div>
+                        </a>
+                        <div class="friend-card-actions">
+                            <form method="post" action="{{ url_for('user.send_friend_request', friend_id=user_data.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn add-friend-btn">Add Friend</button>
+                            </form>
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
         {% else %}
             <p>No other players found.</p>


### PR DESCRIPTION
This submission improves the Community Hub by making it more interactive and visually cleaner.

Key changes:
1. **Interactive Cards**: User cards in both "Your Friends" and "Discover Players" are now clickable, leading to the user's profile. Hover states have been added for visual feedback.
2. **Clean Discovery List**: The "Discover Players" section was moved from a cluttered table to a modern card grid. Labels like "Name:" and "Username:" were removed in favor of a clean hierarchy (Avatar -> Bold Name -> @Username).
3. **Rating Badges**: DUPR ratings are now displayed as compact badges with a star icon.
4. **Header Optimization**: The "Invite a Friend" button now sits next to the title instead of taking up a full row, letting content sit higher on the screen.
5. **Safety**: Careful HTML structuring ensures that clicking "Challenge" or "Add Friend" does not accidentally trigger profile navigation.

All changes were verified visually via Playwright and through existing unit tests.

Fixes #765

---
*PR created automatically by Jules for task [6771597120003811163](https://jules.google.com/task/6771597120003811163) started by @brewmarsh*