### PR TITLE
Refactor Admin Controller to Service Layer

### DIFF
--- a/pickaladder/admin/services.py
+++ b/pickaladder/admin/services.py
@@ -1,0 +1,64 @@
+"""Service layer for admin-related operations."""
+
+from firebase_admin import auth, firestore
+
+
+class AdminService:
+    """Service class for admin-related operations."""
+
+    @staticmethod
+    def build_friend_graph(db):
+        """Build a dictionary of nodes and edges for a friendship graph."""
+        users = db.collection("users").stream()
+        nodes = []
+        edges = []
+        for user in users:
+            user_data = user.to_dict()
+            nodes.append({"id": user.id, "label": user_data.get("username", user.id)})
+            # Fetch friends for this user
+            friends_query = (
+                db.collection("users")
+                .document(user.id)
+                .collection("friends")
+                .where(filter=firestore.FieldFilter("status", "==", "accepted"))
+                .stream()
+            )
+            for friend in friends_query:
+                # Add edge only once
+                if user.id < friend.id:
+                    edges.append({"from": user.id, "to": friend.id})
+        return {"nodes": nodes, "edges": edges}
+
+    @staticmethod
+    def toggle_setting(db, setting_key):
+        """Toggle a boolean setting in the Firestore 'settings' collection."""
+        setting_ref = db.collection("settings").document(setting_key)
+        setting = setting_ref.get()
+        current_value = (
+            setting.to_dict().get("value", False) if setting.exists else False
+        )
+        new_value = not current_value
+        setting_ref.set({"value": new_value})
+        return new_value
+
+    @staticmethod
+    def delete_user(db, user_id):
+        """Delete a user from Firebase Auth and Firestore."""
+        # Delete from Firebase Auth
+        auth.delete_user(user_id)
+        # Delete from Firestore
+        db.collection("users").document(user_id).delete()
+
+    @staticmethod
+    def promote_user(db, user_id):
+        """Promote a user to admin status in Firestore."""
+        user_ref = db.collection("users").document(user_id)
+        user_ref.update({"isAdmin": True})
+        return user_ref.get().to_dict().get("username", "user")
+
+    @staticmethod
+    def verify_user(db, user_id):
+        """Manually verify a user's email in Auth and Firestore."""
+        auth.update_user(user_id, email_verified=True)
+        user_ref = db.collection("users").document(user_id)
+        user_ref.update({"email_verified": True})


### PR DESCRIPTION
This PR refactors the admin controller to follow the "Thin Controller, Fat Model" pattern. 

Key changes:
- New `AdminService` layer in `pickaladder/admin/services.py`.
- Moved heavy business and database logic out of `pickaladder/admin/routes.py`.
- Added missing admin authorization decorators to several routes.
- Maintained existing functionality while improving code organization and security.

Fixes #801

---
*PR created automatically by Jules for task [9879733096414354672](https://jules.google.com/task/9879733096414354672) started by @brewmarsh*