### PR TITLE
Fix avatar display styling

### DIFF
--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -154,10 +154,7 @@ body {
 }
 
 .profile-picture-thumbnail {
-    width: 40px;
-    height: 40px;
     border-radius: 50%;
-    object-fit: cover;
 }
 
 /* Forms */
@@ -358,10 +355,7 @@ input:focus, textarea:focus, select:focus {
 
 /* Profile Elements */
 .profile-picture {
-    width: 120px;
-    height: 120px;
     border-radius: 50%;
-    object-fit: cover;
     margin-bottom: 20px;
     border: 4px solid var(--card-bg);
     box-shadow: var(--box-shadow);

--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -336,3 +336,27 @@ body {
         justify-content: space-between;
     }
 }
+/* Profiles & Avatars */
+.profile-picture {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+}
+
+.profile-picture-large {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.profile-picture-thumbnail {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+}
+
+.avatar {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}


### PR DESCRIPTION
This change fixes the user avatar styling by adding object-fit: cover and ensuring proper dimensions for all avatar-related classes in pickaladder/static/style.css. This prevents blank spaces (letterboxing) from appearing inside circular masks when using non-square images. It also cleans up redundant structural properties in pickaladder/static/dark.css.

Fixes #806

---
*PR created automatically by Jules for task [6462532844701346928](https://jules.google.com/task/6462532844701346928) started by @brewmarsh*