### PR TITLE
Fix Groups Overview image layout on mobile

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -335,4 +335,18 @@ body {
         display: flex;
         justify-content: space-between;
     }
+
+    /* Prevent oversized images in cards */
+    .card img, .group-card img {
+        max-width: 100%;
+        height: auto;
+        object-fit: cover;
+    }
+
+    /* Force consistent group avatars in lists */
+    .group-profile-picture, .group-avatar, .group-avatar-large {
+        width: 60px !important;
+        height: 60px !important;
+        flex-shrink: 0;
+    }
 }


### PR DESCRIPTION
This change fixes the oversized image layout issue on the Groups Overview page for mobile devices. It introduces generic constraints for images within cards and specific fixed dimensions for group avatars in lists within the 768px media query in style.css. These changes ensure that images do not overflow their containers and avatars remain consistent in size on smaller screens.

Fixes #803

---
*PR created automatically by Jules for task [16939501434087582017](https://jules.google.com/task/16939501434087582017) started by @brewmarsh*