### PR TITLE
Arch Step 1: Core Model Refactor

### DIFF
--- a/pickaladder/constants.py
+++ b/pickaladder/constants.py
@@ -1,46 +1,70 @@
-"""Constants used throughout the application."""
+"""Constants used throughout the application.
 
-# Database-related constants
-DB_NAME = "pickaladder"
+Note: This module is deprecated. Use pickaladder.core.constants instead.
+"""
 
-# External Links
-# Placeholder - confirm official base URL
-DUPR_PROFILE_BASE_URL = "REPLACE_WITH_ACTUAL_DUPR_URL"
+from pickaladder.core.constants import (
+    DB_NAME,
+    DUPR_PROFILE_BASE_URL,
+    FRIENDS_FRIEND_ID,
+    FRIENDS_STATUS,
+    FRIENDS_TABLE,
+    FRIENDS_USER_ID,
+    MATCH_DATE,
+    MATCH_ID,
+    MATCH_PLAYER1_ID,
+    MATCH_PLAYER1_SCORE,
+    MATCH_PLAYER2_ID,
+    MATCH_PLAYER2_SCORE,
+    MATCHES_TABLE,
+    MIGRATION_ID,
+    MIGRATION_NAME,
+    MIGRATIONS_TABLE,
+    USER_DARK_MODE,
+    USER_DUPR_RATING,
+    USER_EMAIL,
+    USER_EMAIL_VERIFIED,
+    USER_ID,
+    USER_IS_ADMIN,
+    USER_NAME,
+    USER_PASSWORD,
+    USER_PROFILE_PICTURE,
+    USER_PROFILE_PICTURE_THUMBNAIL,
+    USER_RESET_TOKEN,
+    USER_RESET_TOKEN_EXPIRATION,
+    USER_USERNAME,
+    USERS_TABLE,
+)
 
-# Table names
-USERS_TABLE = "users"
-FRIENDS_TABLE = "friends"
-MATCHES_TABLE = "matches"
-MIGRATIONS_TABLE = "migrations"
-
-# Columns for 'users' table
-USER_ID = "id"
-USER_USERNAME = "username"
-USER_PASSWORD = "password"  # nosec B105
-USER_EMAIL = "email"
-USER_NAME = "name"
-USER_DUPR_RATING = "dupr_rating"
-USER_IS_ADMIN = "is_admin"
-USER_PROFILE_PICTURE = "profile_picture"
-USER_PROFILE_PICTURE_THUMBNAIL = "profile_picture_thumbnail"
-USER_DARK_MODE = "dark_mode"
-USER_EMAIL_VERIFIED = "email_verified"
-USER_RESET_TOKEN = "reset_token"  # nosec B105
-USER_RESET_TOKEN_EXPIRATION = "reset_token_expiration"  # nosec B105
-
-# Columns for 'friends' table
-FRIENDS_USER_ID = "user_id"
-FRIENDS_FRIEND_ID = "friend_id"
-FRIENDS_STATUS = "status"
-
-# Columns for 'matches' table
-MATCH_ID = "id"
-MATCH_PLAYER1_ID = "player1_id"
-MATCH_PLAYER2_ID = "player2_id"
-MATCH_PLAYER1_SCORE = "player1_score"
-MATCH_PLAYER2_SCORE = "player2_score"
-MATCH_DATE = "match_date"
-
-# Columns for 'migrations' table
-MIGRATION_ID = "id"
-MIGRATION_NAME = "migration_name"
+__all__ = [
+    "DB_NAME",
+    "DUPR_PROFILE_BASE_URL",
+    "FRIENDS_FRIEND_ID",
+    "FRIENDS_STATUS",
+    "FRIENDS_TABLE",
+    "FRIENDS_USER_ID",
+    "MATCH_DATE",
+    "MATCH_ID",
+    "MATCH_PLAYER1_ID",
+    "MATCH_PLAYER1_SCORE",
+    "MATCH_PLAYER2_ID",
+    "MATCH_PLAYER2_SCORE",
+    "MATCHES_TABLE",
+    "MIGRATION_ID",
+    "MIGRATION_NAME",
+    "MIGRATIONS_TABLE",
+    "USER_DARK_MODE",
+    "USER_DUPR_RATING",
+    "USER_EMAIL",
+    "USER_EMAIL_VERIFIED",
+    "USER_ID",
+    "USER_IS_ADMIN",
+    "USER_NAME",
+    "USER_PASSWORD",
+    "USER_PROFILE_PICTURE",
+    "USER_PROFILE_PICTURE_THUMBNAIL",
+    "USER_RESET_TOKEN",
+    "USER_RESET_TOKEN_EXPIRATION",
+    "USER_USERNAME",
+    "USERS_TABLE",
+]

--- a/pickaladder/core/__init__.py
+++ b/pickaladder/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core module for the pickaladder application."""
+
+from .types import APIResponse, FirestoreDocument
+
+__all__ = ["FirestoreDocument", "APIResponse"]

--- a/pickaladder/core/constants.py
+++ b/pickaladder/core/constants.py
@@ -1,0 +1,54 @@
+"""Global constants for the pickaladder application."""
+
+# Database-related constants
+DB_NAME = "pickaladder"
+FIRESTORE_BATCH_LIMIT = 400
+
+# External Links
+# Placeholder - confirm official base URL
+DUPR_PROFILE_BASE_URL = "REPLACE_WITH_ACTUAL_DUPR_URL"
+
+# Table names
+USERS_TABLE = "users"
+FRIENDS_TABLE = "friends"
+MATCHES_TABLE = "matches"
+MIGRATIONS_TABLE = "migrations"
+
+# Columns for 'users' table
+USER_ID = "id"
+USER_USERNAME = "username"
+USER_PASSWORD = "password"  # nosec B105
+USER_EMAIL = "email"
+USER_NAME = "name"
+USER_DUPR_RATING = "dupr_rating"
+USER_IS_ADMIN = "is_admin"
+USER_PROFILE_PICTURE = "profile_picture"
+USER_PROFILE_PICTURE_THUMBNAIL = "profile_picture_thumbnail"
+USER_DARK_MODE = "dark_mode"
+USER_EMAIL_VERIFIED = "email_verified"
+USER_RESET_TOKEN = "reset_token"  # nosec B105
+USER_RESET_TOKEN_EXPIRATION = "reset_token_expiration"  # nosec B105
+
+# Columns for 'friends' table
+FRIENDS_USER_ID = "user_id"
+FRIENDS_FRIEND_ID = "friend_id"
+FRIENDS_STATUS = "status"
+
+# Columns for 'matches' table
+MATCH_ID = "id"
+MATCH_PLAYER1_ID = "player1_id"
+MATCH_PLAYER2_ID = "player2_id"
+MATCH_PLAYER1_SCORE = "player1_score"
+MATCH_PLAYER2_SCORE = "player2_score"
+MATCH_DATE = "match_date"
+
+# Columns for 'migrations' table
+MIGRATION_ID = "id"
+MIGRATION_NAME = "migration_name"
+
+# Group-related constants
+RECENT_MATCHES_LIMIT = 5
+HOT_STREAK_THRESHOLD = 3
+
+# Email-related constants
+SMTP_AUTH_ERROR_CODE = 534

--- a/pickaladder/core/types.py
+++ b/pickaladder/core/types.py
@@ -1,0 +1,23 @@
+"""Core data types for the pickaladder application."""
+
+from typing import Any, Dict, Optional, TypedDict  # noqa: UP035
+
+
+class _FirestoreDocumentBase(TypedDict):
+    id: str
+    created_at: Any
+
+
+class FirestoreDocument(_FirestoreDocumentBase, total=False):
+    """Generic Firestore document structure."""
+
+    path: str
+    updated_at: Any
+
+
+class APIResponse(TypedDict):
+    """Generic API response structure."""
+
+    success: bool
+    message: str
+    data: Optional[Dict[str, Any]]  # noqa: UP006

--- a/pickaladder/group/utils.py
+++ b/pickaladder/group/utils.py
@@ -15,12 +15,13 @@ if TYPE_CHECKING:
     from flask import Flask
 from google.cloud.firestore import FieldFilter
 
+from pickaladder.core.constants import (
+    FIRESTORE_BATCH_LIMIT,
+    HOT_STREAK_THRESHOLD,
+    RECENT_MATCHES_LIMIT,
+)
 from pickaladder.user.helpers import smart_display_name
 from pickaladder.utils import send_email
-
-FIRESTORE_BATCH_LIMIT = 400
-RECENT_MATCHES_LIMIT = 5
-HOT_STREAK_THRESHOLD = 3
 
 
 def get_random_joke() -> str:

--- a/pickaladder/user/routes.py
+++ b/pickaladder/user/routes.py
@@ -21,7 +21,7 @@ from flask import (
 from werkzeug.utils import secure_filename
 
 from pickaladder.auth.decorators import login_required
-from pickaladder.constants import DUPR_PROFILE_BASE_URL
+from pickaladder.core.constants import DUPR_PROFILE_BASE_URL
 from pickaladder.utils import EmailError, send_email
 
 from . import bp

--- a/pickaladder/utils.py
+++ b/pickaladder/utils.py
@@ -8,9 +8,9 @@ from typing import Any
 from flask import current_app, render_template
 from flask_mail import Message
 
-from .extensions import mail
+from pickaladder.core.constants import SMTP_AUTH_ERROR_CODE
 
-SMTP_AUTH_ERROR_CODE = 534
+from .extensions import mail
 
 
 class EmailError(Exception):

--- a/tests/test_dupr_link.py
+++ b/tests/test_dupr_link.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from pickaladder import create_app
-from pickaladder.constants import DUPR_PROFILE_BASE_URL
+from pickaladder.core.constants import DUPR_PROFILE_BASE_URL
 
 
 class DuprLinkTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR implements Arch Step 1 of the Core Model Refactor. It introduces a `pickaladder/core` package that houses base data types and utilities, specifically `FirestoreDocument` and `APIResponse` TypedDicts, and a centralized `constants.py` file. This change improves architectural consistency and provides a foundation for future model refactorings. Existing references to moved constants have been updated, and a backward-compatible shim has been maintained in the original constants file.

Fixes #825

---
*PR created automatically by Jules for task [3516432107634583615](https://jules.google.com/task/3516432107634583615) started by @brewmarsh*