### PR TITLE
Refactor Data Layer to Distributed Domain-Driven Models

### DIFF
--- a/pickaladder/group/models.py
+++ b/pickaladder/group/models.py
@@ -1,0 +1,29 @@
+"""Data models for the group blueprint."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from pickaladder.core.types import FirestoreDocument
+
+if TYPE_CHECKING:
+    from pickaladder.user.models import User
+
+
+class Member(TypedDict, total=False):
+    """Represents a group member."""
+
+    userRef: User | Any
+    status: str
+    role: str
+
+
+class Group(FirestoreDocument, total=False):
+    """A group document in Firestore."""
+
+    name: str
+    description: str
+    members: list[Member]
+    ownerRef: User | Any
+    is_public: bool
+    profilePictureUrl: str

--- a/pickaladder/match/models.py
+++ b/pickaladder/match/models.py
@@ -1,0 +1,38 @@
+"""Data models for the match blueprint."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from pickaladder.core.types import FirestoreDocument
+
+if TYPE_CHECKING:
+    from pickaladder.user.models import User
+
+
+class Score(TypedDict, total=False):
+    """Represents a match score."""
+
+    player1Score: int
+    player2Score: int
+
+
+class Match(FirestoreDocument, Score, total=False):
+    """A match document in Firestore."""
+
+    matchType: str
+    matchDate: Any
+    # player1Score and player2Score are inherited from Score
+    player1Ref: User | Any
+    player2Ref: User | Any
+    team1: list[User | Any]
+    team2: list[User | Any]
+    team1Id: str
+    team2Id: str
+    team1Ref: Any
+    team2Ref: Any
+    groupId: str
+    tournamentId: str
+    status: str
+    winnerId: str
+    participants: list[str]

--- a/pickaladder/tournament/models.py
+++ b/pickaladder/tournament/models.py
@@ -1,0 +1,34 @@
+"""Data models for the tournament blueprint."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from pickaladder.core.types import FirestoreDocument
+
+if TYPE_CHECKING:
+    from pickaladder.user.models import User
+
+
+class Participant(TypedDict, total=False):
+    """Represents a tournament participant."""
+
+    userRef: User | Any
+    user_id: str
+    status: str
+    team_name: str
+    email: str
+
+
+class Tournament(FirestoreDocument, total=False):
+    """A tournament document in Firestore."""
+
+    name: str
+    status: str
+    date: Any
+    location: str
+    matchType: str
+    organizer_id: str
+    ownerRef: User | Any
+    participants: list[Participant]
+    participant_ids: list[str]

--- a/pickaladder/user/helpers.py
+++ b/pickaladder/user/helpers.py
@@ -6,34 +6,36 @@ from typing import TYPE_CHECKING, Any
 
 from pickaladder.utils import mask_email
 
-from .models import User
+from .models import User, UserSession
 
 if TYPE_CHECKING:
     pass
 
 
-def wrap_user(user_data: dict[str, Any] | None, uid: str | None = None) -> User | None:
-    """Wrap a user dictionary in a User model object.
+def wrap_user(
+    user_data: dict[str, Any] | User | None, uid: str | None = None
+) -> UserSession | None:
+    """Wrap a user dictionary in a UserSession model object.
 
     Args:
-        user_data: The user data dictionary from Firestore.
+        user_data: The user data dictionary from Firestore or a User TypedDict.
         uid: Optional user ID if not present in user_data.
 
     Returns:
-        A User model object or None if user_data is None.
+        A UserSession model object or None if user_data is None.
     """
     if user_data is None:
         return None
-    if isinstance(user_data, User):
+    if isinstance(user_data, UserSession):
         return user_data
 
     data = dict(user_data)
     if uid:
         data["uid"] = uid
-    return User(data)
+    return UserSession(data)
 
 
-def smart_display_name(user: dict[str, Any]) -> str:
+def smart_display_name(user: dict[str, Any] | User) -> str:
     """Return a smart display name for a user.
 
     If the user is a ghost user (is_ghost is True or username starts with 'ghost_'):

--- a/pickaladder/user/models.py
+++ b/pickaladder/user/models.py
@@ -1,12 +1,41 @@
 """Data models for the user blueprint."""
 
 from collections import UserDict
+from typing import TypedDict
 
 from flask_login import UserMixin
 
+from pickaladder.core.types import FirestoreDocument
 
-class User(UserDict, UserMixin):
-    """A wrapper class for user data that provides additional properties."""
+
+class FriendRequest(TypedDict, total=False):
+    """A friend request document in Firestore."""
+
+    status: str
+    initiator: bool
+
+
+class User(FirestoreDocument, total=False):
+    """A user document in Firestore."""
+
+    email: str
+    username: str
+    name: str
+    is_ghost: bool
+    profilePictureUrl: str
+    profilePictureThumbnailUrl: str
+    dupr_id: str
+    dupr_rating: float
+    duprRating: float
+    isAdmin: bool
+    lastMatchRecordedType: str
+    dark_mode: bool
+    email_verified: bool
+    uid: str
+
+
+class UserSession(UserDict, UserMixin):
+    """A wrapper class for user data that provides properties for Flask-Login."""
 
     def get_id(self) -> str:
         """Return the user ID."""
@@ -15,8 +44,6 @@ class User(UserDict, UserMixin):
     @property
     def avatar_url(self) -> str:
         """Return a deterministic avatar URL based on the user ID."""
-        # Try to get the user ID from various common keys
-
         # If the user has a profile picture, use it
         thumbnail = self.get("profilePictureThumbnailUrl")
         if thumbnail:

--- a/tests/test_best_buds.py
+++ b/tests/test_best_buds.py
@@ -34,6 +34,11 @@ class BestBudsTestCase(unittest.TestCase):
             patch(
                 "pickaladder.group.routes.firestore", new=self.mock_firestore_service
             ),
+            patch(
+                "pickaladder.group.services.group_service.firestore",
+                new=self.mock_firestore_service,
+            ),
+            patch("pickaladder.group.utils.firestore", new=self.mock_firestore_service),
             patch("pickaladder.firestore", new=self.mock_firestore_service),
         ]
         for p in self.patchers:
@@ -49,8 +54,14 @@ class BestBudsTestCase(unittest.TestCase):
             p.stop()
         self.app_context.pop()
 
+    @patch(
+        "pickaladder.group.services.group_service.get_group_leaderboard",
+        return_value=[],
+    )
     @patch("pickaladder.group.routes.get_group_leaderboard", return_value=[])
-    def test_best_buds_identification(self, mock_leaderboard: MagicMock) -> None:
+    def test_best_buds_identification(
+        self, mock_leaderboard_routes: MagicMock, mock_leaderboard_service: MagicMock
+    ) -> None:
         # Set session
         with self.client.session_transaction() as sess:
             sess["user_id"] = "user1"


### PR DESCRIPTION
This submission refactors the data layer to implement Domain-Driven Models as requested in Arch Step 2. 

Key changes include:
- `pickaladder/user/models.py`: Added `User` and `FriendRequest` TypedDicts. Renamed existing `User` class to `UserSession` to preserve Flask-Login functionality.
- `pickaladder/match/models.py`: Created with `Match` and `Score` TypedDicts. `Match` inherits from `Score` to maintain a flat structure while utilizing specific types.
- `pickaladder/group/models.py`: Created with `Group` and `Member` TypedDicts.
- `pickaladder/tournament/models.py`: Created with `Tournament` and `Participant` TypedDicts.
- `pickaladder/user/helpers.py`: Updated `wrap_user` to handle the new `User` TypedDict and return `UserSession` objects.

All models utilize inheritance from `pickaladder.core.types.FirestoreDocument` and use string-based type hints (via `from __future__ import annotations` and `TYPE_CHECKING`) to handle circular dependencies. Linting and formatting have been verified using `ruff`, and all 91 unit/integration tests passed.

Fixes #826

---
*PR created automatically by Jules for task [6875563529434457374](https://jules.google.com/task/6875563529434457374) started by @brewmarsh*