### PR TITLE
Implement Group Leaderboard Brag Card

### DIFF
--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -507,3 +507,23 @@ def get_rivalry_stats(group_id: str) -> Any:
         "avg_points_scored": stats["avg_points_scored"],
         "partnership_record": stats["partnership_record"],
     }
+
+
+@bp.route("/<string:group_id>/user-trend/<string:user_id>")
+@login_required
+def get_user_group_trend(group_id: str, user_id: str) -> Any:
+    """Return trend data for a specific user in a group."""
+    trend_data = get_leaderboard_trend_data(group_id)
+
+    # Filter for the specific user
+    user_dataset = next(
+        (ds for ds in trend_data["datasets"] if ds.get("id") == user_id), None
+    )
+
+    if not user_dataset:
+        return {"error": "User data not found for this group"}, 404
+
+    return {
+        "labels": trend_data["labels"],
+        "dataset": user_dataset,
+    }

--- a/pickaladder/group/utils.py
+++ b/pickaladder/group/utils.py
@@ -319,6 +319,7 @@ def _calculate_trend_points(
     player_stats = {pid: {"total_score": 0, "games": 0} for pid in players_data}
     datasets = {
         pid: {
+            "id": pid,
             "label": info["name"],
             "data": [],
             "fill": False,

--- a/pickaladder/static/css/components.css
+++ b/pickaladder/static/css/components.css
@@ -226,3 +226,80 @@
         flex-shrink: 0;
     }
 }
+/* Brag Card Styles */
+.brag-card {
+    background: linear-gradient(135deg, #111827 0%, #1f2937 100%);
+    border: 2px solid var(--accent-color);
+    border-radius: 16px;
+    padding: 30px;
+    width: 320px;
+    height: 400px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    color: white;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+    position: relative;
+    margin: 0 auto;
+}
+
+.brag-card-header {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.brag-card-avatar {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    border: 3px solid var(--accent-color);
+    object-fit: cover;
+}
+
+.brag-card-username {
+    font-family: 'Oswald', sans-serif;
+    font-size: 1.8rem;
+    text-transform: uppercase;
+    margin: 0;
+    color: var(--accent-color);
+}
+
+.brag-card-main {
+    text-align: center;
+    margin: 20px 0;
+}
+
+.brag-card-stat-label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.brag-card-stat-value {
+    font-family: 'Oswald', sans-serif;
+    font-size: 3.5rem;
+    font-weight: 700;
+    color: white;
+    line-height: 1;
+    margin-top: 5px;
+}
+
+.brag-card-visual {
+    height: 100px;
+    width: 100%;
+    margin: 10px 0;
+}
+
+.brag-card-footer {
+    text-align: center;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-color);
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+    padding-top: 15px;
+    margin-top: auto;
+}

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -68,13 +68,22 @@
                                         </span>
                                     </td>
                                     <td>
-                                        <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link-compact">
-                                            <img src="{{ player | avatar_url }}" alt="{{ player | display_name }}" class="avatar-small" onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
-                                            <span class="player-name-compact">{{ player | display_name }}</span>
-                                            {% if player.is_on_fire %}
-                                                <span title="{{ player.streak }} Game Streak!">🔥</span>
+                                        <div class="d-flex align-items-center justify-content-between">
+                                            <a href="{{ url_for('user.view_user', user_id=player.id) }}" class="player-link-compact">
+                                                <img src="{{ player | avatar_url }}" alt="{{ player | display_name }}" class="avatar-small" onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
+                                                <span class="player-name-compact">{{ player | display_name }}</span>
+                                                {% if player.is_on_fire %}
+                                                    <span title="{{ player.streak }} Game Streak!">🔥</span>
+                                                {% endif %}
+                                            </a>
+                                            {% if player.id == g.user['uid'] %}
+                                                <button class="btn btn-volt small share-stats-btn"
+                                                        style="width: auto; margin-left: 10px; padding: 4px 8px; font-size: 0.7rem;"
+                                                        onclick="openBragCard('{{ player.id }}', '{{ player | display_name }}', '{{ player | avatar_url }}', '{{ loop.index }}', '{{ player.streak }}')">
+                                                    Share Stats
+                                                </button>
                                             {% endif %}
-                                        </a>
+                                        </div>
                                     </td>
                                     <td>
                                         <div class="form-dots-compact">
@@ -366,6 +375,39 @@
 </div>
 {% endif %}
 
+<!-- Brag Card Modal -->
+<div class="modal fade" id="bragCardModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document" style="max-width: 400px;">
+        <div class="modal-content" style="background: transparent; border: none; box-shadow: none;">
+            <div class="modal-body p-0">
+                <div id="bragCardContainer" class="brag-card">
+                    <div class="brag-card-header">
+                        <img id="bragCardAvatar" src="" alt="Avatar" class="brag-card-avatar">
+                        <h2 id="bragCardUsername" class="brag-card-username"></h2>
+                    </div>
+                    <div class="brag-card-main">
+                        <div id="bragCardStatLabel" class="brag-card-stat-label"></div>
+                        <div id="bragCardStatValue" class="brag-card-stat-value"></div>
+                    </div>
+                    <div class="brag-card-visual">
+                        <canvas id="bragCardSparkline"></canvas>
+                    </div>
+                    <div class="brag-card-footer">
+                        Pickaladder - {{ group.name }}
+                    </div>
+                </div>
+                <div class="mt-4 text-center">
+                    <p class="text-white mb-2" style="text-shadow: 0 2px 4px rgba(0,0,0,0.5);">Screenshot this card to share!</p>
+                    <button type="button" class="btn btn-volt" data-dismiss="modal" style="width: auto;">Done</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 function openTab(evt, tabName) {
     var i, tabcontent, tabbuttons;
@@ -381,5 +423,87 @@ function openTab(evt, tabName) {
     evt.currentTarget.className += " active";
 }
 
+let bragCardChart = null;
+
+function openBragCard(userId, username, avatar, rank, streak) {
+    document.getElementById('bragCardUsername').innerText = username;
+    document.getElementById('bragCardAvatar').src = avatar;
+
+    // Determine main stat
+    const streakNum = parseInt(streak) || 0;
+    const rankNum = parseInt(rank) || 0;
+
+    if (rankNum === 1) {
+        document.getElementById('bragCardStatLabel').innerText = 'GROUP RANKING';
+        document.getElementById('bragCardStatValue').innerText = 'RANK #1';
+    } else if (streakNum >= 3) {
+        document.getElementById('bragCardStatLabel').innerText = 'CURRENT STREAK';
+        document.getElementById('bragCardStatValue').innerText = streakNum + ' WINS';
+    } else {
+        document.getElementById('bragCardStatLabel').innerText = 'GROUP RANKING';
+        document.getElementById('bragCardStatValue').innerText = 'RANK #' + rankNum;
+    }
+
+    // Show modal
+    $('#bragCardModal').modal('show');
+
+    // Fetch trend data
+    fetch(`/group/{{ group.id }}/user-trend/${userId}`)
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                console.error(data.error);
+                return;
+            }
+            renderSparkline(data.dataset.data);
+        })
+        .catch(err => console.error("Error fetching trend data:", err));
+}
+
+function renderSparkline(trendData) {
+    const canvas = document.getElementById('bragCardSparkline');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+
+    if (bragCardChart) {
+        bragCardChart.destroy();
+    }
+
+    // Filter out nulls for the sparkline
+    const cleanData = trendData.filter(v => v !== null);
+
+    // Fallback color if CSS variable is not available
+    const accentColor = getComputedStyle(document.documentElement).getPropertyValue('--accent-color').trim() || '#c3ff00';
+
+    bragCardChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: cleanData.map((_, i) => i),
+            datasets: [{
+                data: cleanData,
+                borderColor: accentColor,
+                borderWidth: 4,
+                pointRadius: 0,
+                fill: false,
+                tension: 0.4
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: { enabled: false }
+            },
+            scales: {
+                x: { display: false },
+                y: {
+                    display: false,
+                    beginAtZero: false
+                }
+            }
+        }
+    });
+}
 </script>
 {% endblock %}

--- a/tests/test_brag_card.py
+++ b/tests/test_brag_card.py
@@ -1,0 +1,137 @@
+"""Tests for the Brag Card feature."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pickaladder import create_app
+
+MOCK_USER_ID = "user1"
+MOCK_USER_PAYLOAD = {"uid": MOCK_USER_ID, "email": "user1@example.com"}
+
+
+class BragCardTestCase(unittest.TestCase):
+    """Test case for the Brag Card feature."""
+
+    def setUp(self) -> None:
+        """Set up a test client and a comprehensive mock environment."""
+        self.mock_firestore_service = MagicMock()
+
+        patchers = {
+            "init_app": patch("firebase_admin.initialize_app"),
+            "firestore_routes": patch(
+                "pickaladder.group.routes.firestore", new=self.mock_firestore_service
+            ),
+            "firestore_app": patch(
+                "pickaladder.firestore", new=self.mock_firestore_service
+            ),
+            "verify_id_token": patch("firebase_admin.auth.verify_id_token"),
+        }
+
+        self.mocks = {name: p.start() for name, p in patchers.items()}
+        for p in patchers.values():
+            self.addCleanup(p.stop)
+
+        self.app = create_app(
+            {"TESTING": True, "WTF_CSRF_ENABLED": False, "SERVER_NAME": "localhost"}
+        )
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self) -> None:
+        """Tear down the test client."""
+        self.app_context.pop()
+
+    def _set_session_user(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = MOCK_USER_ID
+            sess["is_admin"] = False
+        self.mocks["verify_id_token"].return_value = MOCK_USER_PAYLOAD
+
+        # Mock the user document for before_request load_logged_in_user
+        mock_db = self.mock_firestore_service.client.return_value
+        mock_user_doc = MagicMock()
+        mock_user_doc.exists = True
+        mock_user_doc.to_dict.return_value = {
+            "username": "testuser",
+            "email": "test@example.com",
+        }
+        mock_db.collection.return_value.document.return_value.get.return_value = (
+            mock_user_doc
+        )
+
+    def _get_auth_headers(self) -> dict[str, str]:
+        return {"Authorization": "Bearer mock-token"}
+
+    def test_get_user_group_trend(self) -> None:
+        """Test successfully fetching user-specific trend data."""
+        self._set_session_user()
+
+        group_id = "test_group"
+        user_id = MOCK_USER_ID
+
+        mock_trend_data = {
+            "labels": ["2023-01-01", "2023-01-02"],
+            "datasets": [
+                {
+                    "id": user_id,
+                    "label": "Test User",
+                    "data": [10.5, 12.0],
+                    "profilePictureUrl": None,
+                }
+            ],
+        }
+
+        with patch(
+            "pickaladder.group.routes.get_leaderboard_trend_data",
+            return_value=mock_trend_data,
+        ):
+            response = self.client.get(
+                f"/group/{group_id}/user-trend/{user_id}",
+                headers=self._get_auth_headers(),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data["labels"], ["2023-01-01", "2023-01-02"])
+        self.assertEqual(data["dataset"]["id"], user_id)
+        self.assertEqual(data["dataset"]["data"], [10.5, 12.0])
+
+    def test_get_user_group_trend_not_found(self) -> None:
+        """Test fetching trend data for a user not in the group."""
+        self._set_session_user()
+
+        group_id = "test_group"
+        user_id = "other_user"
+
+        mock_trend_data = {
+            "labels": ["2023-01-01"],
+            "datasets": [
+                {
+                    "id": "different_user",
+                    "label": "Different User",
+                    "data": [10.5],
+                    "profilePictureUrl": None,
+                }
+            ],
+        }
+
+        with patch(
+            "pickaladder.group.routes.get_leaderboard_trend_data",
+            return_value=mock_trend_data,
+        ):
+            response = self.client.get(
+                f"/group/{group_id}/user-trend/{user_id}",
+                headers=self._get_auth_headers(),
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.get_json()["error"], "User data not found for this group"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change implements a "Shareable Brag Card" on the Group Dashboard. 

Key features:
- UI: A "Share Stats" button in the group leaderboard.
- Trading Card Design: Dark gradient background, large avatar/username, and dynamic highlight stats (Rank or Win Streak).
- Sparkline: A simplified performance trend line using Chart.js in Volt Green.
- Shareable Aspect Ratio: Fixed 4:5 aspect ratio suitable for social media screenshots.
- Backend Support: New API endpoint to fetch user-specific trend data.

Fixes #840

---
*PR created automatically by Jules for task [18035976797991941922](https://jules.google.com/task/18035976797991941922) started by @brewmarsh*