### PR TITLE
Grant pull-request write permissions to Agent Readiness workflow

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 2 * * *' # Nightly at 02:00 UTC on beta
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   agent-readiness:
     name: Agent Readiness Check


### PR DESCRIPTION
This PR adds the necessary `permissions` block to the `agent-readiness.yaml` workflow. By default, tokens for Dependabot PRs have limited permissions, causing the `sticky-pull-request-comment` action to fail. Explicitly granting `pull-requests: write` resolves this issue while maintaining security with `contents: read`.

Fixes #905

---
*PR created automatically by Jules for task [9553187400078596422](https://jules.google.com/task/9553187400078596422) started by @brewmarsh*