### PR TITLE
Groups Page CSS Variable Usage and Verification

### DIFF
--- a/pickaladder/static/css/layout.css
+++ b/pickaladder/static/css/layout.css
@@ -86,7 +86,6 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 24px;
-    margin-top: 20px;
 }
 
 .group-card {
@@ -101,8 +100,6 @@ body {
     width: 100%;
     height: 160px;
     object-fit: cover;
-    border-top-left-radius: var(--border-radius);
-    border-top-right-radius: var(--border-radius);
 }
 
 .card-body {


### PR DESCRIPTION
Verified and updated the CSS definitions for the groups page in `pickaladder/static/css/layout.css` to ensure they match the requested critical classes. 

Changes:
- `.groups-grid`: Removed `margin-top: 20px;`.
- `.group-card-img`: Removed `border-top-left-radius` and `border-top-right-radius`.

Verification:
- Confirmed `groups.html` links to `layout.css` via `layout.html`.
- Created a temporary Playwright E2E test to verify the groups grid and image visibility.
- Captured a screenshot showing the rendered groups grid.
- Ran existing group unit tests and performed linting/formatting checks.

Fixes #916

---
*PR created automatically by Jules for task [1576876821595559163](https://jules.google.com/task/1576876821595559163) started by @brewmarsh*