### PR TITLE
Standardize Group Leaderboard UI

### DIFF
--- a/pickaladder/static/style.css
+++ b/pickaladder/static/style.css
@@ -33,3 +33,8 @@
 .mb-0 { margin-bottom: 0 !important; }
 .mb-4 { margin-bottom: 24px !important; }
 .shadow-sm { box-shadow: 0 .125rem .25rem rgba(0,0,0,.075) !important; }
+
+/* Alignment Utilities */
+.text-left { text-align: left !important; }
+.text-center { text-align: center !important; }
+.text-right { text-align: right !important; }

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -36,6 +36,7 @@
             <h3>Group Leaderboard</h3>
             <p>A live ranking of all group members.</p>
 
+            {% if recent_matches %}
             <div class="tab-container">
                 <div class="tab-buttons">
                     <button class="tab-button active" onclick="openTab(event, 'players')">Players</button>
@@ -44,19 +45,19 @@
 
                 <div id="players" class="tab-content" style="display: block;">
                     <div class="table-container">
-                        <table class="table-standard responsive-table">
+                        <table class="table table-standard responsive-table">
                             <thead>
                                 <tr>
-                                    <th>Rank</th>
-                                    <th>Player</th>
-                                    <th>Form</th>
+                                    <th class="text-center">Rank</th>
+                                    <th class="text-left">Player</th>
+                                    <th class="text-right">Form</th>
                                     <th class="text-right">Avg Score</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {% for player in leaderboard %}
                                 <tr class="{{ 'bg-primary-subtle' if player.id == g.user['uid'] else '' }}">
-                                    <td class="rank-cell">
+                                    <td data-label="Rank" class="rank-cell text-center">
                                         {% if loop.index == 1 %}🥇
                                         {% elif loop.index == 2 %}🥈
                                         {% elif loop.index == 3 %}🥉
@@ -71,7 +72,7 @@
                                         {% endif %}
                                         </span>
                                     </td>
-                                    <td>
+                                    <td data-label="Player" class="text-left">
                                         <div class="d-flex align-items-center justify-content-between">
                                             <a href="{{ url_for('user.view_user', user_id=player.id) }}"
                                                 class="player-link-compact">
@@ -92,20 +93,16 @@
                                             {% endif %}
                                         </div>
                                     </td>
-                                    <td>
+                                    <td data-label="Form" class="text-right">
                                         <div class="form-dots-compact">
                                             {% for result in player.form %}
                                             <span class="form-dot-compact {{ result }}"></span>
                                             {% endfor %}
                                         </div>
                                     </td>
-                                    <td class="text-right font-weight-bold">
+                                    <td data-label="Avg Score" class="text-right font-weight-bold">
                                         {{ "%.2f"|format(player.avg_score|float) }}
                                     </td>
-                                </tr>
-                                {% else %}
-                                <tr>
-                                    <td colspan="4" class="text-center">No matches have been played yet.</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
@@ -115,39 +112,52 @@
 
                 <div id="teams" class="tab-content" style="display: none;">
                     <div class="table-container">
-                        <div class="leaderboard-row header desktop-only">
-                            <div class="font-weight-bold">Rank</div>
-                            <div class="font-weight-bold">Team</div>
-                            <div class="text-right font-weight-bold">W-L</div>
-                        </div>
-                        {% for entry in team_leaderboard %}
-                        <div class="leaderboard-row">
-                            <div class="rank-cell">
-                                {% if loop.index == 1 %}🥇
-                                {% elif loop.index == 2 %}🥈
-                                {% elif loop.index == 3 %}🥉
-                                {% else %}#{{ loop.index }}{% endif %}
-                            </div>
-                            <div>
-                                <div class="team-members-compact">
-                                    {% for member in entry.team.member_details %}
-                                    <img src="{{ member | avatar_url }}" alt="{{ member | display_name }}"
-                                        class="avatar avatar-sm"
-                                        onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
-                                    {% endfor %}
-                                    <span class="team-name-compact">{{ entry.team.name }}</span>
-                                </div>
-                            </div>
-                            <div class="text-right font-weight-bold">
-                                {{ entry.stats.wins }}-{{ entry.stats.losses }}
-                            </div>
-                        </div>
-                        {% else %}
-                        <div class="p-3 text-center">No teams formed yet.</div>
-                        {% endfor %}
+                        <table class="table table-standard responsive-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-center">Rank</th>
+                                    <th class="text-left">Team</th>
+                                    <th class="text-right">W-L</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for entry in team_leaderboard %}
+                                <tr>
+                                    <td data-label="Rank" class="rank-cell text-center">
+                                        {% if loop.index == 1 %}🥇
+                                        {% elif loop.index == 2 %}🥈
+                                        {% elif loop.index == 3 %}🥉
+                                        {% else %}#{{ loop.index }}{% endif %}
+                                    </td>
+                                    <td data-label="Team" class="text-left">
+                                        <div class="team-members-compact">
+                                            {% for member in entry.team.member_details %}
+                                            <img src="{{ member | avatar_url }}" alt="{{ member | display_name }}"
+                                                class="avatar avatar-sm"
+                                                onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
+                                            {% endfor %}
+                                            <span class="team-name-compact">{{ entry.team.name }}</span>
+                                        </div>
+                                    </td>
+                                    <td data-label="W-L" class="text-right font-weight-bold">
+                                        {{ entry.stats.wins }}-{{ entry.stats.losses }}
+                                    </td>
+                                </tr>
+                                {% else %}
+                                <tr>
+                                    <td colspan="3" class="text-center">No teams formed yet.</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             </div>
+            {% else %}
+            <div class="card card-notification text-center">
+                <p class="mb-0">No matches recorded yet. Be the first to play!</p>
+            </div>
+            {% endif %}
 
             <div class="leaderboard-trend-link">
                 <a href="{{ url_for('group.view_leaderboard_trend', group_id=group.id) }}">View Leaderboard Trend


### PR DESCRIPTION
Standardized the group leaderboard tables (Players and Teams) in group.html to use the 'table-standard' system. Added alignment utility classes to the global stylesheet and implemented a friendly empty state card.

Fixes #918

---
*PR created automatically by Jules for task [15776334310472573612](https://jules.google.com/task/15776334310472573612) started by @brewmarsh*