### PR TITLE
Refactor Global Leaderboard Logic and UI

### DIFF
--- a/pickaladder/match/services.py
+++ b/pickaladder/match/services.py
@@ -281,7 +281,8 @@ class MatchService:
     @staticmethod
     def get_leaderboard_data(db: Client, limit: int = 50) -> list[User]:
         """Fetch data for the global leaderboard."""
-        users_query = db.collection("users").limit(limit).stream()
+        # Removing limit from query to ensure we can find top players from whole base
+        users_query = db.collection("users").stream()
         players: list[User] = []
         for user in users_query:
             u_snap = cast("DocumentSnapshot", user)
@@ -309,7 +310,7 @@ class MatchService:
         players.sort(
             key=lambda p: (p.get("win_percentage", 0), p.get("wins", 0)), reverse=True
         )
-        return players
+        return players[:limit]
 
     @staticmethod
     def get_latest_matches(db: Client, limit: int = 10) -> list[Match]:

--- a/pickaladder/templates/leaderboard.html
+++ b/pickaladder/templates/leaderboard.html
@@ -3,14 +3,14 @@
 {% block content %}
     <div class="page-header">
         <h1>Global Leaderboard</h1>
-        <p>Top players by Win Percentage</p>
+        <p>Top Players by Win Percentage</p>
     </div>
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <table class="table table-standard responsive-table">
             <thead>
                 <tr>
                     <th>Rank</th>
-                    <th>PLAYER</th>
+                    <th>Player</th>
                     <th class="text-right">Win Percentage</th>
                     <th class="text-right">Games Played</th>
                 </tr>
@@ -19,7 +19,7 @@
                 {% for player in players %}
                 <tr class="{{ 'highlight-row' if player.id == current_user_id else '' }}">
                     <td data-label="Rank" class="{% if loop.index == 1 %}rank-1{% elif loop.index == 2 %}rank-2{% elif loop.index == 3 %}rank-3{% endif %}">{{ loop.index }}</td>
-                    <td data-label="PLAYER"><a href="{{ url_for('user.view_user', user_id=player.id) }}">{{ player.name }}</a></td>
+                    <td data-label="Player"><a href="{{ url_for('user.view_user', user_id=player.id) }}">{{ player.name }}</a></td>
                     <td data-label="Win Percentage" class="text-right">{{ "%.1f"|format(player.win_percentage|float) }}%</td>
                     <td data-label="Games Played" class="text-right">{{ player.games_played }}</td>
                 </tr>
@@ -30,26 +30,28 @@
     <div class="page-header">
         <h2>Latest Games</h2>
     </div>
-    <div class="latest-games-container">
-        {% for match in latest_matches %}
-        <div class="game-item">
-            <div class="game-date">{{ match.date }}</div>
-            <div class="game-matchup">
-                <div>
-                    <strong class="winner">{{ match.winner_name }}</strong> defeated {{ match.loser_name }}
-                </div>
-                <div class="game-score">
-                    {{ match.winner_score }} - {{ match.loser_score }}
-                </div>
-            </div>
-            <div class="game-details">
-                {% if match.close_call %}
-                    <span class="tag">Close Call</span>
-                {% else %}
-                    <span class="point-differential">{{ match.point_differential }} pt diff</span>
-                {% endif %}
-            </div>
-        </div>
-        {% endfor %}
+    <div class="table-container">
+        <table class="table table-standard">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Matchup</th>
+                    <th>Result</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for match in latest_matches %}
+                <tr>
+                    <td data-label="Date">{{ match.date }}</td>
+                    <td data-label="Matchup">
+                        <strong class="winner">{{ match.winner_name }}</strong> vs {{ match.loser_name }}
+                    </td>
+                    <td data-label="Result">
+                        {{ match.winner_score }} - {{ match.loser_score }}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 {% endblock %}

--- a/tests/test_leaderboard_logic.py
+++ b/tests/test_leaderboard_logic.py
@@ -41,7 +41,7 @@ class TestLeaderboardLogic(unittest.TestCase):
         user3.id = "u3"
         user3.to_dict.return_value = {"name": "User 3"}
 
-        mock_db.collection.return_value.limit.return_value.stream.return_value = [
+        mock_db.collection.return_value.stream.return_value = [
             user1,
             user2,
             user3,


### PR DESCRIPTION
This submission refactors the Global Leaderboard in both the backend and frontend. 

Backend changes:
- In `pickaladder/match/services.py`, the `get_leaderboard_data` method now streams all users to calculate win percentages and rankings globally, rather than limiting the query before calculation. Results are limited to the top 50 in Python after sorting.
- Filtering now strictly enforces the 5-game minimum for leaderboard eligibility.

Frontend changes:
- Standardized the main leaderboard table with appropriate CSS classes and headers.
- Updated the subtitle for clarity.
- Replaced the "Latest Games" list with a clean table layout, bolding match winners for better readability.

Verification:
- Unit tests in `tests/test_leaderboard_logic.py` were updated and pass.
- Match blueprint tests pass.
- Frontend was visually verified via Playwright screenshot.
- Code is clean according to Ruff and Mypy.

Fixes #924

---
*PR created automatically by Jules for task [11240279035089677530](https://jules.google.com/task/11240279035089677530) started by @brewmarsh*