### PR TITLE
Standardize on pytest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: 3.11
 
       - name: Install dependencies
-        run: uv pip install -r requirements.txt mock-firestore coverage --system
+        run: uv pip install -r requirements.txt -r requirements-test.txt coverage --system
 
       - name: Enable uuid-ossp extension
         run: |
@@ -54,8 +54,8 @@ jobs:
           POSTGRES_DB: postgres
           UV_SYSTEM_PYTHON: 1
         run: |
-          uv run --no-project python -m unittest discover tests
-          uv run --no-project python -m coverage run -m unittest discover tests
+          uv run --no-project python -m pytest
+          uv run --no-project python -m coverage run -m pytest
           uv run --no-project python -m coverage xml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: 3.11
 
       - name: Install dependencies
-        run: uv pip install -r requirements.txt mock-firestore coverage --system
+        run: uv pip install -r requirements.txt -r requirements-test.txt coverage --system
 
       - name: Enable uuid-ossp extension
         run: |
@@ -50,8 +50,8 @@ jobs:
           POSTGRES_DB: postgres
           UV_SYSTEM_PYTHON: 1
         run: |
-          uv run --no-project python -m unittest discover tests
-          uv run --no-project python -m coverage run -m unittest discover tests
+          uv run --no-project python -m pytest
+          uv run --no-project python -m coverage run -m pytest
           uv run --no-project python -m coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 mock-firestore==0.11.0
 pytest==9.0.2
 pytest-flask==1.3.0
+pytest-mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,154 +2,16 @@
 
 import unittest.mock
 from collections.abc import Iterator
-from typing import Any, Optional
 
 import pytest
-from mockfirestore import CollectionReference, Query
-from mockfirestore.document import DocumentReference
+
+from tests.mock_utils import MockFirestoreBuilder, patch_mockfirestore
 
 
-class MockArrayUnion:
-    def __init__(self, values: list[Any]) -> None:
-        self.values = values
-
-    def __iter__(self) -> Iterator[Any]:
-        return iter(self.values)
-
-    def __len__(self) -> int:
-        return len(self.values)
-
-
-class MockArrayRemove:
-    def __init__(self, values: list[Any]) -> None:
-        self.values = values
-
-    def __iter__(self) -> Iterator[Any]:
-        return iter(self.values)
-
-    def __len__(self) -> int:
-        return len(self.values)
-
-
-class MockBatch:
-    def __init__(self, db: Any) -> None:
-        self.db = db
-        self.updates: list[tuple[Any, Any]] = []
-        self.commit = unittest.mock.MagicMock(side_effect=self._real_commit)
-
-    def update(self, ref: Any, data: Any) -> None:
-        self.updates.append((ref, data))
-
-    def set(self, ref: Any, data: Any, merge: bool = False) -> None:
-        # For set with merge=True, it's like update.
-        # For simplicity in tests, we just update.
-        self.updates.append((ref, data))
-
-    def delete(self, ref: Any) -> None:
-        self.updates.append((ref, "DELETE"))
-
-    def _real_commit(self) -> None:
-        for ref, data in self.updates:
-            if data == "DELETE":
-                ref.delete()
-            else:
-                ref.update(data)
-
-
-class MockFirestoreBuilder:
-    """Builder to modularize mockfirestore and firebase_admin patching."""
-
-    @staticmethod
-    def patch_db_read() -> None:
-        """Apply monkeypatches to mockfirestore to support FieldFilter and equality."""
-
-        def collection_where(
-            self: Any,
-            field_path: Optional[str] = None,
-            op_string: Optional[str] = None,
-            value: Any = None,
-            filter: Any = None,
-        ) -> Any:  # noqa: E501
-            if filter:
-                return self._where(filter.field_path, filter.op_string, filter.value)
-            return self._where(field_path, op_string, value)
-
-        if not hasattr(CollectionReference, "_where"):
-            CollectionReference._where = CollectionReference.where
-            CollectionReference.where = collection_where
-
-        def query_where(
-            self: Any,
-            field_path: Optional[str] = None,
-            op_string: Optional[str] = None,
-            value: Any = None,
-            filter: Any = None,
-        ) -> Any:
-            if filter:
-                return self._where(filter.field_path, filter.op_string, filter.value)
-            return self._where(field_path, op_string, value)
-
-        if not hasattr(Query, "_where"):
-            Query._where = Query.where
-            Query.where = query_where
-
-        def doc_ref_eq(self: Any, other: Any) -> bool:
-            if not isinstance(other, DocumentReference):
-                return False
-            return self._path == other._path
-
-        if not hasattr(DocumentReference, "_orig_eq"):
-            DocumentReference._orig_eq = DocumentReference.__eq__
-            DocumentReference.__eq__ = doc_ref_eq
-
-        if not hasattr(DocumentReference, "__hash__"):
-            DocumentReference.__hash__ = lambda self: hash(tuple(self._path))
-
-    @staticmethod
-    def patch_db_write() -> None:
-        """Apply monkeypatches to mockfirestore to support update with sentinels."""
-        if not hasattr(DocumentReference, "_orig_update"):
-            DocumentReference._orig_update = DocumentReference.update
-
-            def patched_update(self: Any, data: dict[str, Any]) -> Any:
-                current_data = self.get().to_dict() or {}
-                new_data = {}
-                for k, v in data.items():
-                    if isinstance(v, MockArrayUnion):
-                        existing = current_data.get(k, [])
-                        if not isinstance(existing, list):
-                            existing = []
-                        # Simple append for mock, firestore does set union
-                        merged = list(existing)
-                        for item in v.values:
-                            if item not in merged:
-                                merged.append(item)
-                        new_data[k] = merged
-                    elif isinstance(v, MockArrayRemove):
-                        existing = current_data.get(k, [])
-                        if not isinstance(existing, list):
-                            existing = []
-                        new_data[k] = [i for i in existing if i not in v.values]
-                    else:
-                        new_data[k] = v
-                # MockFirestore's DocumentReference.update updates its internal _data.
-                # Use the original update to ensure any other logic is preserved.
-                return self._orig_update(new_data)
-
-            DocumentReference.update = patched_update
-
-    @staticmethod
-    def patch_db_auth() -> unittest.mock.MagicMock:
-        """Create an autospec'd mock for firebase_admin.auth."""
-        from firebase_admin import auth
-
-        return unittest.mock.create_autospec(auth, spec_set=True)
-
-
-def patch_mockfirestore() -> None:
-    """Apply monkeypatches to mockfirestore to support FieldFilter and equality."""
-    MockFirestoreBuilder.patch_db_read()
-    MockFirestoreBuilder.patch_db_write()
+@pytest.fixture(autouse=True)
+def apply_global_patches() -> None:
+    """Apply global monkeypatches to mockfirestore."""
+    patch_mockfirestore()
 
 
 @pytest.fixture

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -1,0 +1,151 @@
+"""Mock utilities for Firestore and Auth."""
+
+import unittest.mock
+from collections.abc import Iterator
+from typing import Any, Optional
+
+from mockfirestore import CollectionReference, Query
+from mockfirestore.document import DocumentReference
+
+
+class MockArrayUnion:
+    def __init__(self, values: list[Any]) -> None:
+        self.values = values
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self.values)
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+
+class MockArrayRemove:
+    def __init__(self, values: list[Any]) -> None:
+        self.values = values
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self.values)
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+
+class MockBatch:
+    def __init__(self, db: Any) -> None:
+        self.db = db
+        self.updates: list[tuple[Any, Any]] = []
+        self.commit = unittest.mock.MagicMock(side_effect=self._real_commit)
+
+    def update(self, ref: Any, data: Any) -> None:
+        self.updates.append((ref, data))
+
+    def set(self, ref: Any, data: Any, merge: bool = False) -> None:
+        # For set with merge=True, it's like update.
+        # For simplicity in tests, we just update.
+        self.updates.append((ref, data))
+
+    def delete(self, ref: Any) -> None:
+        self.updates.append((ref, "DELETE"))
+
+    def _real_commit(self) -> None:
+        for ref, data in self.updates:
+            if data == "DELETE":
+                ref.delete()
+            else:
+                ref.update(data)
+
+
+class MockFirestoreBuilder:
+    """Builder to modularize mockfirestore and firebase_admin patching."""
+
+    @staticmethod
+    def patch_db_read() -> None:
+        """Apply monkeypatches to mockfirestore to support FieldFilter and equality."""
+
+        def collection_where(
+            self: Any,
+            field_path: Optional[str] = None,
+            op_string: Optional[str] = None,
+            value: Any = None,
+            filter: Any = None,
+        ) -> Any:  # noqa: E501
+            if filter:
+                return self._where(filter.field_path, filter.op_string, filter.value)
+            return self._where(field_path, op_string, value)
+
+        if not hasattr(CollectionReference, "_where"):
+            CollectionReference._where = CollectionReference.where
+            CollectionReference.where = collection_where
+
+        def query_where(
+            self: Any,
+            field_path: Optional[str] = None,
+            op_string: Optional[str] = None,
+            value: Any = None,
+            filter: Any = None,
+        ) -> Any:
+            if filter:
+                return self._where(filter.field_path, filter.op_string, filter.value)
+            return self._where(field_path, op_string, value)
+
+        if not hasattr(Query, "_where"):
+            Query._where = Query.where
+            Query.where = query_where
+
+        def doc_ref_eq(self: Any, other: Any) -> bool:
+            if not isinstance(other, DocumentReference):
+                return False
+            return self._path == other._path
+
+        if not hasattr(DocumentReference, "_orig_eq"):
+            DocumentReference._orig_eq = DocumentReference.__eq__
+            DocumentReference.__eq__ = doc_ref_eq
+
+        if not hasattr(DocumentReference, "__hash__"):
+            DocumentReference.__hash__ = lambda self: hash(tuple(self._path))
+
+    @staticmethod
+    def patch_db_write() -> None:
+        """Apply monkeypatches to mockfirestore to support update with sentinels."""
+        if not hasattr(DocumentReference, "_orig_update"):
+            DocumentReference._orig_update = DocumentReference.update
+
+            def patched_update(self: Any, data: dict[str, Any]) -> Any:
+                current_data = self.get().to_dict() or {}
+                new_data = {}
+                for k, v in data.items():
+                    if isinstance(v, MockArrayUnion):
+                        existing = current_data.get(k, [])
+                        if not isinstance(existing, list):
+                            existing = []
+                        # Simple append for mock, firestore does set union
+                        merged = list(existing)
+                        for item in v.values:
+                            if item not in merged:
+                                merged.append(item)
+                        new_data[k] = merged
+                    elif isinstance(v, MockArrayRemove):
+                        existing = current_data.get(k, [])
+                        if not isinstance(existing, list):
+                            existing = []
+                        new_data[k] = [i for i in existing if i not in v.values]
+                    else:
+                        new_data[k] = v
+                # MockFirestore's DocumentReference.update updates its internal _data.
+                # Use the original update to ensure any other logic is preserved.
+                return self._orig_update(new_data)
+
+            DocumentReference.update = patched_update
+
+    @staticmethod
+    def patch_db_auth() -> unittest.mock.MagicMock:
+        """Create an autospec'd mock for firebase_admin.auth."""
+        from firebase_admin import auth
+
+        return unittest.mock.create_autospec(auth, spec_set=True)
+
+
+def patch_mockfirestore() -> None:
+    """Apply monkeypatches to mockfirestore to support FieldFilter and equality."""
+    MockFirestoreBuilder.patch_db_read()
+    MockFirestoreBuilder.patch_db_write()

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -11,14 +11,11 @@ from mockfirestore import MockFirestore
 
 from pickaladder import create_app
 from pickaladder.tournament import TournamentService  # noqa: F401
-from tests.conftest import (
+from tests.mock_utils import (
     MockArrayRemove,
     MockArrayUnion,
     MockBatch,
-    patch_mockfirestore,
 )
-
-patch_mockfirestore()
 
 # Mock user payloads
 MOCK_USER_ID = "user1"

--- a/tests/test_tournament_blast.py
+++ b/tests/test_tournament_blast.py
@@ -10,14 +10,11 @@ from mockfirestore import MockFirestore
 
 from pickaladder import create_app
 from pickaladder.user import UserService
-from tests.conftest import (
+from tests.mock_utils import (
     MockArrayRemove,
     MockArrayUnion,
     MockBatch,
-    patch_mockfirestore,
 )
-
-patch_mockfirestore()
 
 # Mock user payloads
 MOCK_USER_ID = "owner_id"


### PR DESCRIPTION
Modernized the testing pipeline by transitioning from unittest to pytest. This included updating dependencies, refactoring test infrastructure to eliminate conftest.py import anti-patterns, and updating the CI/CD workflows to leverage pytest features.

Fixes #932

---
*PR created automatically by Jules for task [723614947560022592](https://jules.google.com/task/723614947560022592) started by @brewmarsh*