### PR TITLE
Fix Playwright Dependency in CI

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    uses: ./.github/workflows/reusable-ci.yml
+    uses: ./.github/workflows/run_tests.yaml
 
   versioning:
     needs: ci
@@ -20,4 +20,3 @@ jobs:
     with:
       namespace: "beta"
     secrets: inherit
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,61 +9,8 @@ on:
 jobs:
   ci:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Install dependencies
-        run: uv pip install -r requirements.txt -r requirements-test.txt coverage --system
-
-      - name: Enable uuid-ossp extension
-        run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
-          PGPASSWORD=postgres psql -h localhost -U postgres -p 5432 -d postgres -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
-
-      - name: Run tests
-        env:
-          DB_HOST: localhost
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-          UV_SYSTEM_PYTHON: 1
-        run: |
-          uv run --no-project python -m pytest
-          uv run --no-project python -m coverage run -m pytest
-          uv run --no-project python -m coverage xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: true
+    uses: ./.github/workflows/run_tests.yaml
+    secrets: inherit
 
   versioning:
     needs: ci

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,10 +1,10 @@
-name: Reusable CI
+name: Run Tests
 
 on:
   workflow_call:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -37,6 +37,14 @@ jobs:
       - name: Install dependencies
         run: uv pip install -r requirements.txt -r requirements-test.txt coverage --system
 
+      - name: Install Playwright
+        run: uv pip install playwright pytest-playwright --system
+
+      - name: Install Playwright Browsers
+        env:
+          UV_SYSTEM_PYTHON: 1
+        run: uv run --no-project playwright install --with-deps
+
       - name: Enable uuid-ossp extension
         run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
@@ -53,6 +61,7 @@ jobs:
           uv run --no-project python -m pytest
           uv run --no-project python -m coverage run -m pytest
           uv run --no-project python -m coverage xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,5 @@ mock-firestore==0.11.0
 pytest==9.0.2
 pytest-flask==1.3.0
 pytest-mock
+playwright
+pytest-playwright


### PR DESCRIPTION
This submission fixes the Playwright dependency issue in the CI pipeline by ensuring all necessary packages and browser binaries are installed. It also unifies the test execution logic into a single reusable workflow (`run_tests.yaml`) used by both `main` and `beta` branches, improving maintainability and reducing duplication.

Fixes #942

---
*PR created automatically by Jules for task [6974187352135762696](https://jules.google.com/task/6974187352135762696) started by @brewmarsh*