### PR TITLE
Fix Firebase initialization in tests and E2E failures

### DIFF
--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -192,7 +192,7 @@
                                             style="font-size: 0.85rem;">{{ request.username }}</a>
                                     </td>
                                     <td style="padding: 8px; text-align: right;">
-                                        <form action="{{ url_for('user.accept_friend_request', friend_id=request.id) }}"
+                                        <form action="{{ url_for('user.accept_request', requester_id=request.id) }}"
                                             method="post" style="display: inline;">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-volt btn-sm"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 
 import unittest.mock
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
+from mockfirestore import MockFirestore
 
+from pickaladder import create_app
 from tests.mock_utils import MockFirestoreBuilder, patch_mockfirestore
 
 
@@ -12,6 +15,31 @@ from tests.mock_utils import MockFirestoreBuilder, patch_mockfirestore
 def apply_global_patches() -> None:
     """Apply global monkeypatches to mockfirestore."""
     patch_mockfirestore()
+
+
+@pytest.fixture
+def mock_db() -> MockFirestore:
+    """Fixture to provide a mock Firestore database."""
+    return MockFirestore()
+
+
+@pytest.fixture
+def app(mock_db: MockFirestore) -> Iterator[Any]:
+    """Create and configure a new app instance for each test."""
+    # Patch firestore.client globally to return our mock_db
+    with (
+        unittest.mock.patch("firebase_admin.firestore.client", return_value=mock_db),
+        unittest.mock.patch("firebase_admin.initialize_app"),
+        unittest.mock.patch("firebase_admin.auth"),
+    ):
+        app = create_app(
+            {
+                "TESTING": True,
+                "WTF_CSRF_ENABLED": False,
+                "SERVER_NAME": "localhost",
+            }
+        )
+        yield app
 
 
 @pytest.fixture

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -63,17 +63,14 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     )
 
     # 3. Add Friend (User 2 invites Admin)
-    page.click("text=Friends")
-    page.click("text=Find New Friends")
+    page.click("text=Community")
 
     page.fill("input[name='search']", "admin")
-    page.click("input[value='Search']")
+    page.click("button:has-text('🔍')")
 
     # Click Add Friend for Admin User
     page.click("button:has-text('Add Friend')")
-    expect(page.locator("button:has-text('Friend Request Sent')")).to_be_visible(
-        timeout=5000
-    )
+    expect(page.locator("button:has-text('Request Sent')")).to_be_visible(timeout=5000)
 
     # Logout User 2, Login Admin
     page.click(".dropbtn")
@@ -84,7 +81,7 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     page.click("input[value='Login']")
 
     # Accept Friend Request
-    page.click("text=Friends")
+    page.click("text=Community")
     expect(page.locator("text=user2")).to_be_visible()
     page.click("button:has-text('Accept')")
     expect(page.locator("text=user2")).to_be_visible()


### PR DESCRIPTION
The Flask application was skipping `firebase_admin.initialize_app` during tests when `TESTING=True` was set, which caused subsequent calls to `firestore.client()` in routes and context processors to raise a `ValueError`. 

This PR refactors the central `app` fixture in `tests/conftest.py` to intercept and mock these calls using `unittest.mock.patch`. Similar improvements were applied to the E2E test infrastructure in `tests/e2e/conftest.py` to ensure the mock server also avoids real Firebase initialization. 

Additionally, this PR fixes a template bug where an incorrect route was being used for accepting friend requests and updates the E2E test scenarios to match recent UI changes (e.g., "Community" instead of "Friends").

Fixes #944

---
*PR created automatically by Jules for task [3966501416608615700](https://jules.google.com/task/3966501416608615700) started by @brewmarsh*