### PR TITLE
Fix ambiguous test selectors and E2E failures

### DIFF
--- a/pickaladder/match/services.py
+++ b/pickaladder/match/services.py
@@ -62,11 +62,15 @@ class MatchService:
         # Determine Date
         match_date_input = get_val("match_date")
         if isinstance(match_date_input, str) and match_date_input:
-            match_date = datetime.datetime.strptime(match_date_input, "%Y-%m-%d")
+            match_date = datetime.datetime.strptime(
+                match_date_input, "%Y-%m-%d"
+            ).replace(tzinfo=datetime.timezone.utc)
         elif isinstance(match_date_input, datetime.date):
-            match_date = datetime.datetime.combine(match_date_input, datetime.time.min)
+            match_date = datetime.datetime.combine(
+                match_date_input, datetime.time.min
+            ).replace(tzinfo=datetime.timezone.utc)
         else:
-            match_date = datetime.datetime.now()
+            match_date = datetime.datetime.now(datetime.timezone.utc)
 
         player1_score = int(get_val("player1_score") or 0)
         player2_score = int(get_val("player2_score") or 0)
@@ -223,7 +227,7 @@ class MatchService:
 
         Optionally restricts to a group or tournament.
         """
-        candidate_player_ids: set[str] = set()
+        candidate_player_ids: set[str] = {user_id}
 
         if tournament_id:
             # If in a tournament context, candidates are tournament participants

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -82,13 +82,13 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
 
     # Accept Friend Request
     page.click("text=Community")
-    expect(page.locator("text=user2")).to_be_visible()
+    expect(page.locator(".incoming-requests-section", has_text="user2")).to_be_visible()
     page.click("button:has-text('Accept')")
-    expect(page.locator("text=user2")).to_be_visible()
+    expect(page.locator(".friend-card", has_text="user2")).to_be_visible()
 
     # 4. Create Group
     page.click("text=Groups")
-    page.click("text=Create New Group")
+    page.click("text=Create Group")
     page.fill("input[name='name']", "Pickleballers")
     page.fill("input[name='location']", "Test Court")
     page.click("input[value='Create Group']")
@@ -96,6 +96,7 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     expect(page.locator("h1")).to_contain_text("Pickleballers")
 
     # 5. Invite Friend to Group
+    page.click("summary:has-text('Manage Group & Members')")
     page.select_option("select[name='friend']", value="user2")
     page.click("input[value='Invite Friend']")
 
@@ -114,10 +115,11 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     # 6. Score Individual Game (User 2 vs Admin)
     page.goto(f"{base_url}/match/record")
     page.select_option("select[name='match_type']", value="singles")
+    page.select_option("select[name='player1']", value="user2")
     page.select_option("select[name='player2']", value="admin")
     page.fill("input[name='player1_score']", "11")
     page.fill("input[name='player2_score']", "9")
-    page.click("input[value='Record Match']")
+    page.click("button:has-text('Record Match')")
 
     # Check flash message
     expect(page.locator(".alert-success")).to_contain_text(
@@ -128,10 +130,11 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     page.click("text=Groups")
     page.click("text=Pickleballers")
     page.click("a:has-text('Record a Match')")
+    page.select_option("select[name='player1']", value="user2")
     page.select_option("select[name='player2']", value="admin")
     page.fill("input[name='player1_score']", "5")
     page.fill("input[name='player2_score']", "11")
-    page.click("input[value='Record Match']")
+    page.click("button:has-text('Record Match')")
 
     expect(page.locator("h1")).to_contain_text("Pickleballers")
     expect(page.locator(".alert-success")).to_contain_text(
@@ -139,11 +142,11 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     )
 
     # Check Global Leaderboard (Req: "see the leaderboard")
-    page.click("text=Global Leaderboard")
+    page.click("text=Leaderboard")
     expect(page.locator("h1")).to_contain_text("Global Leaderboard")
     # Verify players are listed
-    expect(page.locator("td", has_text="Admin User")).to_be_visible()
-    expect(page.locator("td", has_text="User Two")).to_be_visible()
+    expect(page.locator("td", has_text="Admin User").first).to_be_visible()
+    expect(page.locator("td", has_text="User Two").first).to_be_visible()
 
     # 8. Delete Group Game & 9. Delete Individual Game
     # Needs Admin access

--- a/tests/e2e/test_tournament.py
+++ b/tests/e2e/test_tournament.py
@@ -25,6 +25,7 @@ def test_tournament_flow(
         page.click("input[value='Create Admin']")
         page.wait_for_url("**/auth/login")
 
+    page.wait_for_selector("input[name='email']")
     page.fill("input[name='email']", "admin@example.com")
     page.fill("input[name='password']", "password")
     page.click(".btn:has-text('Login')")


### PR DESCRIPTION
I fixed the ambiguous selectors in `tests/e2e/test_e2e.py` and added the requested wait condition in `tests/e2e/test_tournament.py`. 

Additionally, I discovered and fixed several issues that were causing the E2E tests to fail:
1.  **UI Sync:** Updated button text ('Create Group'), navigation links ('Leaderboard'), and added a step to open the 'Manage Group & Members' accordion in the group view.
2.  **Candidate Players Bug:** The `MatchService.get_candidate_player_ids` method was excluding the current user, which made it impossible for the E2E test (or a real user) to select themselves as player1 in the singles match form. I updated the service to include the user by default.
3.  **Timezone Mismatch:** Fixed a `TypeError` where offset-naive datetimes from match records were being compared to offset-aware datetimes in the leaderboard logic. I ensured all match dates are created as UTC-aware.
4.  **Selector Specificity:** Updated match recording assertions and actions to be more robust against current template structure.

Fixes #947

---
*PR created automatically by Jules for task [12170308209790242283](https://jules.google.com/task/12170308209790242283) started by @brewmarsh*