### PR TITLE
Refactor E2E Tests for Stability

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -23,12 +23,14 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
         page.fill("input[name='email']", "admin@example.com")
         page.fill("input[name='password']", "password")
         page.fill("input[name='name']", "Admin User")
-        page.click("input[value='Create Admin']")
+        with page.expect_navigation():
+            page.click("input[value='Create Admin']")
 
         expect(page.locator("h2")).to_contain_text("Login")
         page.fill("input[name='email']", "admin@example.com")
         page.fill("input[name='password']", "password")
-        page.click("input[value='Login']")
+        with page.expect_navigation():
+            page.click("input[value='Login']")
 
     page.click("#edit-profile-toggle")
     expect(page.locator("h3:has-text('Profile Information')")).to_be_visible(
@@ -37,11 +39,13 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
 
     # Logout
     page.click(".dropbtn", force=True)
-    page.click("text=Logout", force=True)
+    with page.expect_navigation():
+        page.click("text=Logout", force=True)
     expect(page.locator("h2")).to_contain_text("Login")
 
     # 2. Register User 2
-    page.click("text=Register")
+    with page.expect_navigation():
+        page.click("text=Register")
     page.wait_for_url("**/auth/register")
     page.fill("input[name='username']", "user2")
     page.fill("input[name='email']", "user2@example.com")
@@ -49,13 +53,15 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     page.fill("input[name='confirm_password']", "MyPassword123")
     page.fill("input[name='name']", "User Two")
     page.fill("input[name='dupr_rating']", "3.5")
-    page.click("input[value='Register']")
+    with page.expect_navigation():
+        page.click("input[value='Register']")
 
     # Now login as User Two
     expect(page.locator("h2")).to_contain_text("Login")
     page.fill("input[name='email']", "user2@example.com")
     page.fill("input[name='password']", "MyPassword123")
-    page.click("input[value='Login']")
+    with page.expect_navigation():
+        page.click("input[value='Login']")
 
     page.click("#edit-profile-toggle")
     expect(page.locator("h3:has-text('Profile Information')")).to_be_visible(
@@ -63,13 +69,16 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     )
 
     # 3. Add Friend (User 2 invites Admin)
-    page.click("text=Community")
+    with page.expect_navigation():
+        page.click("text=Community")
 
     page.fill("input[name='search']", "admin")
-    page.click("button:has-text('🔍')")
+    with page.expect_navigation():
+        page.click("button:has-text('🔍')")
 
     # Click Add Friend for Admin User
-    page.click("button:has-text('Add Friend')")
+    with page.expect_navigation():
+        page.click("button:has-text('Add Friend')")
     # After reload, the user should be in the "Sent Friend Requests" section
     expect(page.locator(".requests-section", has_text="admin")).to_be_visible(
         timeout=5000
@@ -77,42 +86,54 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
 
     # Logout User 2, Login Admin
     page.click(".dropbtn", force=True)
-    page.click("text=Logout", force=True)
+    with page.expect_navigation():
+        page.click("text=Logout", force=True)
+    expect(page.locator("h2")).to_contain_text("Login")
 
     page.fill("input[name='email']", "admin@example.com")
     page.fill("input[name='password']", "password")
-    page.click("input[value='Login']")
+    with page.expect_navigation():
+        page.click("input[value='Login']")
 
     # Accept Friend Request
-    page.click("text=Community")
+    with page.expect_navigation():
+        page.click("text=Community")
     expect(page.locator(".incoming-requests-section", has_text="user2")).to_be_visible()
-    page.click("button:has-text('Accept')")
+    with page.expect_navigation():
+        page.click("button:has-text('Accept')")
     expect(page.locator(".friend-card", has_text="user2")).to_be_visible()
 
     # 4. Create Group
-    page.click("text=Groups")
-    page.click("text=Create Group")
+    with page.expect_navigation():
+        page.click("text=Groups")
+    with page.expect_navigation():
+        page.click("text=Create Group")
     page.fill("input[name='name']", "Pickleballers")
     page.fill("input[name='location']", "Test Court")
-    page.click("input[value='Create Group']")
+    with page.expect_navigation():
+        page.click("input[value='Create Group']")
 
     expect(page.locator("h1")).to_contain_text("Pickleballers")
 
     # 5. Invite Friend to Group
     page.click("summary:has-text('Manage Group & Members')")
     page.select_option("select[name='friend']", value="user2")
-    page.click("input[value='Invite Friend']")
+    with page.expect_navigation():
+        page.click("input[value='Invite Friend']")
 
     # Verify User 2 is added (Logout Admin, Login User 2)
     page.click(".dropbtn", force=True)
-    page.click("text=Logout", force=True)
+    with page.expect_navigation():
+        page.click("text=Logout", force=True)
 
     page.fill("input[name='email']", "user2@example.com")
     page.fill("input[name='password']", "MyPassword123")
-    page.click("input[value='Login']")
+    with page.expect_navigation():
+        page.click("input[value='Login']")
 
     # User 2 should see the group
-    page.click("text=Groups")
+    with page.expect_navigation():
+        page.click("text=Groups")
     expect(page.locator("text=Pickleballers")).to_be_visible()
 
     # 6. Score Individual Game (User 2 vs Admin)
@@ -122,7 +143,8 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     page.select_option("select[name='player2']", value="admin")
     page.fill("input[name='player1_score']", "11")
     page.fill("input[name='player2_score']", "9")
-    page.click("button:has-text('Record Match')")
+    with page.expect_navigation():
+        page.click("button:has-text('Record Match')")
 
     # Check flash message
     expect(page.locator(".alert-success")).to_contain_text(
@@ -130,14 +152,18 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     )
 
     # 7. Score Group Game
-    page.click("text=Groups")
-    page.click("text=Pickleballers")
-    page.click("a:has-text('Record a Match')")
+    with page.expect_navigation():
+        page.click("text=Groups")
+    with page.expect_navigation():
+        page.click("text=Pickleballers")
+    with page.expect_navigation():
+        page.click("a:has-text('Record a Match')")
     page.select_option("select[name='player1']", value="user2")
     page.select_option("select[name='player2']", value="admin")
     page.fill("input[name='player1_score']", "5")
     page.fill("input[name='player2_score']", "11")
-    page.click("button:has-text('Record Match')")
+    with page.expect_navigation():
+        page.click("button:has-text('Record Match')")
 
     expect(page.locator("h1")).to_contain_text("Pickleballers")
     expect(page.locator(".alert-success")).to_contain_text(
@@ -145,7 +171,8 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     )
 
     # Check Global Leaderboard (Req: "see the leaderboard")
-    page.click("text=Leaderboard")
+    with page.expect_navigation():
+        page.click("text=Leaderboard")
     expect(page.locator("h1")).to_contain_text("Global Leaderboard")
     # Verify players are listed
     expect(page.locator("td", has_text="Admin User").first).to_be_visible()
@@ -154,33 +181,42 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     # 8. Delete Group Game & 9. Delete Individual Game
     # Needs Admin access
     page.click(".dropbtn", force=True)
-    page.click("text=Logout", force=True)
+    with page.expect_navigation():
+        page.click("text=Logout", force=True)
 
     page.fill("input[name='email']", "admin@example.com")
     page.fill("input[name='password']", "password")
-    page.click("input[value='Login']")
+    with page.expect_navigation():
+        page.click("input[value='Login']")
 
     page.goto(f"{base_url}/admin/matches")
     # Delete match involving user2 (first one)
-    page.click("button:has-text('Delete')")
+    with page.expect_navigation():
+        page.click("button:has-text('Delete')")
     expect(page.locator(".alert-success")).to_contain_text("Match deleted successfully")
 
     # Delete second match
-    page.click("button:has-text('Delete')")
+    with page.expect_navigation():
+        page.click("button:has-text('Delete')")
     expect(page.locator(".alert-success")).to_contain_text("Match deleted successfully")
 
     # 10. Update Group Details (Login as Admin - already logged in)
-    page.click("text=Groups")
-    page.click("text=Pickleballers")
-    page.click("text=Edit Group")
+    with page.expect_navigation():
+        page.click("text=Groups")
+    with page.expect_navigation():
+        page.click("text=Pickleballers")
+    with page.expect_navigation():
+        page.click("text=Edit Group")
     page.fill("input[name='location']", "New Court")
-    page.click("input[value='Update Group']")
+    with page.expect_navigation():
+        page.click("input[value='Update Group']")
     expect(page.locator("text=New Court")).to_be_visible()
 
     # 11. Invite Email to Group
     page.fill("form[action*='group'] input[name='name']", "New Guy")
     page.fill("form[action*='group'] input[name='email']", "newguy@example.com")
-    page.click("input[value='Send Invite']")
+    with page.expect_navigation():
+        page.click("input[value='Send Invite']")
     expect(page.locator(".alert-toast, .alert-success, .toast-body")).to_contain_text(
         "Invitation is being sent"
     )

--- a/tests/e2e/test_tournament.py
+++ b/tests/e2e/test_tournament.py
@@ -22,22 +22,27 @@ def test_tournament_flow(
         page.fill("input[name='email']", "admin@example.com")
         page.fill("input[name='password']", "password")
         page.fill("input[name='name']", "Admin User")
-        page.click("input[value='Create Admin']")
+        with page.expect_navigation():
+            page.click("input[value='Create Admin']")
         page.wait_for_url("**/auth/login")
 
     page.wait_for_selector("input[name='email']")
     page.fill("input[name='email']", "admin@example.com")
     page.fill("input[name='password']", "password")
-    page.click(".btn:has-text('Login')")
+    with page.expect_navigation():
+        page.click(".btn:has-text('Login')")
 
     # 2. Create a Tournament
-    page.click("text=Tournaments")
-    page.click("text=Create Tournament")
+    with page.expect_navigation():
+        page.click("text=Tournaments")
+    with page.expect_navigation():
+        page.click("text=Create Tournament")
     page.fill("input[name='name']", "Winter Open")
     page.fill("input[name='date']", "2026-12-01")
     page.fill("input[name='location']", "Central Park")
     page.select_option("select[name='match_type']", value="singles")
-    page.click("button:has-text('Create Tournament')")
+    with page.expect_navigation():
+        page.click("button:has-text('Create Tournament')")
 
     expect(page.locator("h2")).to_contain_text("Winter Open")
     expect(page.locator(".badge-warning", has_text="Active")).to_be_visible()
@@ -68,7 +73,8 @@ def test_tournament_flow(
     )
 
     # 4. Complete Tournament (as owner)
-    page.click("text=Complete Tournament")
+    with page.expect_navigation():
+        page.click("text=Complete Tournament")
 
     expect(page.locator(".badge-success", has_text="Completed")).to_be_visible()
     # Podium is only shown if there are matches, but we verified the flow works.


### PR DESCRIPTION
This submission refactors the E2E test suite to eliminate race conditions by using Playwright's `expect_navigation` context manager for all actions that trigger a page load. It also adds explicit assertions to verify page state before proceeding with form interactions, particularly during user login/logout transitions.

Fixes #956

---
*PR created automatically by Jules for task [7000606715815016042](https://jules.google.com/task/7000606715815016042) started by @brewmarsh*