### PR TITLE
Update E2E test with new group UI

### DIFF
--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -3,7 +3,8 @@
 {% block content %}
 <div class="card hero-stats-card">
     {% if group.ownerRef.id == current_user_id %}
-    <a href="{{ url_for('group.edit_group', group_id=group.id) }}" title="Group Settings" class="btn-edit-gear">⚙️</a>
+    <a href="{{ url_for('group.edit_group', group_id=group.id) }}" title="Group Settings" class="btn-edit-gear"
+        data-testid="group-settings-btn">⚙️</a>
     {% endif %}
 
     <div class="hero-left-panel">

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -206,13 +206,14 @@ def test_user_journey(app_server: str, page_with_firebase: Page, mock_db: Any) -
     with page.expect_navigation():
         page.click("text=Pickleballers")
     with page.expect_navigation():
-        page.click("text=Edit Group")
+        page.click('[data-testid="group-settings-btn"]')
     page.fill("input[name='location']", "New Court")
     with page.expect_navigation():
         page.click("input[value='Update Group']")
     expect(page.locator("text=New Court")).to_be_visible()
 
     # 11. Invite Email to Group
+    page.click("summary:has-text('Manage Group & Members')")
     page.fill("form[action*='group'] input[name='name']", "New Guy")
     page.fill("form[action*='group'] input[name='email']", "newguy@example.com")
     with page.expect_navigation():


### PR DESCRIPTION
Updated the Group Hero UI by adding a `data-testid` to the settings icon and adjusted the E2E test suite to use this new identifier. Additionally, fixed a test failure where the invitation form was hidden inside a collapsed `<details>` block by adding a step to expand it before interaction.

Fixes #958

---
*PR created automatically by Jules for task [2895124922281846139](https://jules.google.com/task/2895124922281846139) started by @brewmarsh*