### PR TITLE
Fix leaderboard accessibility and mobile contrast

### DIFF
--- a/pickaladder/static/mobile.css
+++ b/pickaladder/static/mobile.css
@@ -196,4 +196,52 @@
         padding: 1px 6px;
         font-size: 0.8rem;
     }
+
+    /* Improved Responsive Table for Mobile (Card View) */
+    .responsive-table td {
+        display: flex !important;
+        justify-content: space-between !important;
+        align-items: center !important;
+        padding: 10px 15px !important;
+    }
+
+    .responsive-table td::before {
+        position: static !important;
+        width: auto !important;
+        margin-right: 10px !important;
+        padding-right: 0 !important;
+        font-weight: 700 !important;
+    }
+
+    /* Leaderboard Rank Badges for Mobile Accessibility */
+    .responsive-table td[data-label="Rank"].rank-1,
+    .responsive-table td[data-label="Rank"].rank-2,
+    .responsive-table td[data-label="Rank"].rank-3 {
+        background-color: #111827 !important;
+        padding: 12px 15px !important;
+        border-radius: 8px 8px 0 0;
+        border-bottom: none !important;
+    }
+
+    .responsive-table td[data-label="Rank"].rank-1 { color: #FFD700 !important; }
+    .responsive-table td[data-label="Rank"].rank-2 { color: #C0C0C0 !important; }
+    .responsive-table td[data-label="Rank"].rank-3 { color: #CD7F32 !important; }
+
+    .responsive-table td[data-label="Rank"].rank-1::before,
+    .responsive-table td[data-label="Rank"].rank-2::before,
+    .responsive-table td[data-label="Rank"].rank-3::before {
+        color: #FFFFFF !important;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+    }
+
+    /* Ensure Labels are Bold and Distinct */
+    .responsive-table td[data-label="Win Percentage"]::before,
+    .responsive-table td[data-label="Games Played"]::before {
+        color: var(--text-secondary) !important;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+    }
 }


### PR DESCRIPTION
This PR fixes accessibility issues on the mobile leaderboard. 

Key changes:
1. **Rank Contrast**: Top three ranks now have a dark badge background (#111827) which ensures that the Gold, Silver, and Bronze colors are clearly visible and pass WCAG AA contrast ratios (Rank 1 is ~12.5:1).
2. **Layout Improvements**: The responsive table cells on mobile now use flexbox to ensure labels and values are properly aligned on opposite sides of the card, preventing overlap.
3. **Typography**: Labels for "Win Percentage" and "Games Played" are now uppercase and use a secondary text color to distinguish them from the data values while remaining bold and readable.

Verified visually via Playwright screenshots and confirmed that all 109 unit/integration tests pass.

Fixes #964

---
*PR created automatically by Jules for task [9332693360375518545](https://jules.google.com/task/9332693360375518545) started by @brewmarsh*