### PR TITLE
Fix Desktop Navbar Visibility

### DIFF
--- a/pickaladder/static/css/components.css
+++ b/pickaladder/static/css/components.css
@@ -3,6 +3,13 @@
 .mx-auto { margin-left: auto !important; margin-right: auto !important; }
 .gap-4 { gap: 1.5rem !important; }
 .justify-content-center { justify-content: center !important; }
+.d-none { display: none !important; }
+
+@media screen and (min-width: 992px) {
+    body .d-lg-none { display: none !important; }
+    body .d-lg-flex { display: flex !important; }
+    body .d-lg-block { display: block !important; }
+}
 
 /* Buttons */
 .btn {

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -1,11 +1,26 @@
+{% macro brand_logo() %}
+<a href="{{ url_for('user.dashboard') }}" class="navbar-brand" style="display: flex; align-items: center;">
+    <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" alt="pickaladder logo"
+        style="height: 24px; margin-right: 8px;">
+    pickaladder
+</a>
+{% endmacro %}
+
 <header class="header">
     <div class="container">
-        <nav class="navbar">
-            <a href="{{ url_for('user.dashboard') }}" class="navbar-brand" style="display: flex; align-items: center;">
-                <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" alt="pickaladder logo"
-                    style="height: 24px; margin-right: 8px;">
-                pickaladder
-            </a>
+        <!-- Mobile Header -->
+        <div class="d-flex justify-content-between align-items-center d-lg-none w-100">
+            {{ brand_logo() }}
+            <button class="hamburger-menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+
+        <!-- Desktop Navbar -->
+        <nav class="navbar d-none d-lg-flex">
+            {{ brand_logo() }}
             <div class="navbar-menu">
                 {% if g.user %}
                 <a href="{{ url_for('user.dashboard') }}"
@@ -64,14 +79,9 @@
                     </div>
                 </div>
                 {% endif %}
-                <button class="hamburger-menu">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
             </div>
         </nav>
-        <div id="myLinks" class="mobile-nav">
+        <div id="myLinks" class="mobile-nav d-lg-none">
             {% if g.user %}
             <a href="{{ url_for('user.dashboard') }}" class="mobile-nav-link"><i class="fas fa-home me-2"></i> Dashboard</a>
             <a href="{{ url_for('user.view_community') }}" class="mobile-nav-link"><i class="fas fa-users me-2"></i> Community</a>


### PR DESCRIPTION
The mobile navigation menu was incorrectly visible on desktop screens. This PR fixes the layout bug by:
1. Defining standard responsive visibility utility classes in `components.css`.
2. Applying `d-lg-none` to the mobile navigation container to hide it on desktop.
3. Applying `d-none d-lg-flex` to the main desktop navbar.
4. Adding a dedicated mobile header for branding and menu toggling on mobile devices.
5. Using a Jinja2 macro to avoid duplicating the brand logo HTML.
6. Optimizing the DOM structure so the mobile hamburger menu is correctly picked up by the existing JavaScript.

Fixes #984

---
*PR created automatically by Jules for task [3573299195318295765](https://jules.google.com/task/3573299195318295765) started by @brewmarsh*