### PR TITLE
Fix Navbar Visibility and Desktop Layout Regression

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -45,3 +45,12 @@
 .page-header-actions h1 {
     margin-bottom: 0 !important;
 }
+
+/* --- Responsive Visibility Utilities --- */
+body .d-none { display: none !important; }
+
+@media (min-width: 992px) {
+    body .d-lg-none { display: none !important; }
+    body .d-lg-flex { display: flex !important; }
+    body .d-lg-block { display: block !important; }
+}

--- a/pickaladder/static/css/layout.css
+++ b/pickaladder/static/css/layout.css
@@ -66,6 +66,15 @@ body {
     gap: 15px;
 }
 
+.desktop-auth-buttons {
+    display: flex;
+    gap: 10px;
+}
+
+.desktop-auth-buttons .btn {
+    width: auto;
+}
+
 .dashboard-columns {
     display: flex;
     gap: 24px;

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -81,6 +81,7 @@
                 {% endif %}
             </div>
         </nav>
+        <!-- Mobile Menu -->
         <div id="myLinks" class="mobile-nav d-lg-none">
             {% if g.user %}
             <a href="{{ url_for('user.dashboard') }}" class="mobile-nav-link"><i class="fas fa-home me-2"></i>


### PR DESCRIPTION
This submission fixes a layout regression where the mobile navigation menu was visible on desktop screens. The root cause was the absence of responsive visibility utility classes in the application's CSS. I defined these classes in `layout-utils.css` and also addressed a related styling issue in the desktop navbar where buttons were taking full width, mimicking a mobile layout. Verification was performed using automated tests and visual inspections via Playwright.

Fixes #1024

---
*PR created automatically by Jules for task [13690353037397854587](https://jules.google.com/task/13690353037397854587) started by @brewmarsh*