### PR TITLE
Fix transparent background on share and brag cards

### DIFF
--- a/pickaladder/static/css/cards.css
+++ b/pickaladder/static/css/cards.css
@@ -111,12 +111,14 @@
 
 /* Social Share Card */
 .social-share-card {
-    background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-hover) 100%);
+    background-color: var(--primary-color);
+    background-image: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-hover) 100%);
     border-radius: 20px;
     padding: 30px;
     color: white;
     text-align: center;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    opacity: 1;
 }
 
 .social-share-card-header {
@@ -147,4 +149,66 @@
     margin-top: 30px;
     font-size: 0.85rem;
     opacity: 0.7;
+}
+
+/* Brag Card (Share Stats) */
+.brag-card {
+    background-color: var(--card-bg);
+    border-radius: 20px;
+    padding: 30px;
+    color: var(--text-primary);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    opacity: 1;
+    margin: 0 auto;
+}
+
+.brag-card-header {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    margin-bottom: 25px;
+}
+
+.brag-card-avatar {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.brag-card-username {
+    font-size: 1.5rem;
+    margin: 0;
+    font-weight: 700;
+}
+
+.brag-card-main {
+    text-align: center;
+    margin-bottom: 25px;
+}
+
+.brag-card-stat-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    margin-bottom: 5px;
+}
+
+.brag-card-stat-value {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: var(--primary-color);
+    line-height: 1;
+}
+
+.brag-card-visual {
+    margin-bottom: 20px;
+    height: 100px;
+}
+
+.brag-card-footer {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    opacity: 0.8;
 }


### PR DESCRIPTION
This PR fixes the transparency issue on the "Share Card" and "Brag Card" modals which caused background text to bleed through and make the cards unreadable.

Key changes:
1.  **New Brag Card Styles**: Added missing CSS for the `.brag-card` component used for sharing user stats.
2.  **Solid Backgrounds**: Explicitly set `background-color` and `opacity: 1` for both `.social-share-card` and `.brag-card`.
3.  **CSS Best Practices**: Refactored `.social-share-card` to use `background-image` for gradients instead of the `background` shorthand, ensuring the `background-color` is correctly applied and testable.
4.  **Verification**: Verified the fix visually using custom verification scripts and ensured existing E2E tests pass.

Fixes #1113

---
*PR created automatically by Jules for task [12314647052150238973](https://jules.google.com/task/12314647052150238973) started by @brewmarsh*