### PR TITLE
Pre-fill "Report a Bug" context on Beta site

### DIFF
--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -319,6 +319,7 @@ def _load_app_config(app: Flask, test_config: dict[str, Any] | None) -> None:
         mail_password = mail_password.strip().replace(" ", "").strip("'").strip('"')
 
     app.config.from_mapping(
+        ENV=os.environ.get("FLASK_ENV") or "development",
         SECRET_KEY=os.environ.get("SECRET_KEY") or "dev",
         FIREBASE_API_KEY=os.environ.get("FIREBASE_API_KEY"),
         GOOGLE_API_KEY=os.environ.get("GOOGLE_API_KEY"),

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -72,7 +72,7 @@
                         <a href="{{ url_for('admin.admin') }}">👑 Admin</a>
                         {% endif %}
                         <div class="dropdown-divider"></div>
-                        <a href="https://github.com/brewmarsh/pickaladder/issues/new" target="_blank">🐛 Report a Bug</a>
+                        <a href="{% if config.get('ENV') == 'beta' %}https://github.com/brewmarsh/pickaladder/issues/new?title=[BETA]+Bug&body=Environment:+Beta{% else %}https://github.com/brewmarsh/pickaladder/issues/new{% endif %}" target="_blank">🐛 Report a Bug</a>
                         <div class="dropdown-divider"></div>
                         <a href="{{ url_for('auth.logout') }}">🚪 Logout</a>
                     </div>
@@ -120,7 +120,7 @@
                 Admin</a>
             {% endif %}
             <div class="mobile-nav-divider"></div>
-            <a href="https://github.com/brewmarsh/pickaladder/issues/new" target="_blank" class="mobile-nav-link">🐛 Report a Bug</a>
+            <a href="{% if config.get('ENV') == 'beta' %}https://github.com/brewmarsh/pickaladder/issues/new?title=[BETA]+Bug&body=Environment:+Beta{% else %}https://github.com/brewmarsh/pickaladder/issues/new{% endif %}" target="_blank" class="mobile-nav-link">🐛 Report a Bug</a>
             <a href="{{ url_for('auth.logout') }}" class="mobile-nav-link"><i class="fas fa-sign-out-alt me-2"></i>
                 Logout</a>
             {% else %}


### PR DESCRIPTION
The "Report a Bug" link in the navbar now auto-fills the GitHub issue with "Environment: BETA" when the application is running in the Beta environment (FLASK_ENV=beta).

Changes:
1.  Modified `pickaladder/__init__.py` to set `ENV` in the Flask app configuration from the `FLASK_ENV` environment variable.
2.  Updated `pickaladder/templates/navbar.html` to use a Jinja conditional for the "Report a Bug" links (both desktop and mobile), pointing them to a pre-filled GitHub URL if `config['ENV']` is 'beta'.
3.  Verified the configuration logic and link rendering using a temporary verification route and Playwright.
4.  Ensured all existing tests pass.

Fixes #1102

---
*PR created automatically by Jules for task [1295591741931555593](https://jules.google.com/task/1295591741931555593) started by @brewmarsh*