### PR TITLE
Fix Jinja2 context and syntax errors in tournament and dashboard templates

### DIFF
--- a/pickaladder/templates/create_tournament.html
+++ b/pickaladder/templates/create_tournament.html
@@ -8,11 +8,11 @@
         <h2>Create Tournament</h2>
     </div>
     <div class="card-body">
-        <form method="POST">
+        <form method="POST" enctype="multipart/form-data">
             {{ form.csrf_token }}
             <div class="form-group">
                 {{ form.name.label(class="form-label") }}
-                {{ form.name(class="form-input") }}
+                {{ form.name(class="form-input", placeholder="Summer Smash 2024") }}
                 {% if form.name.errors %}
                     {% for error in form.name.errors %}
                         <span class="text-danger">{{ error }}</span>
@@ -20,17 +20,27 @@
                 {% endif %}
             </div>
             <div class="form-group">
-                {{ form.date.label(class="form-label") }}
-                {{ form.date(class="form-input", type="date") }}
-                {% if form.date.errors %}
-                    {% for error in form.date.errors %}
+                {{ form.banner.label(class="form-label") }}
+                {{ form.banner(class="form-input") }}
+                <small class="text-muted">Recommended: 16:9 aspect ratio.</small>
+                {% if form.banner.errors %}
+                    {% for error in form.banner.errors %}
+                        <span class="text-danger">{{ error }}</span>
+                    {% endfor %}
+                {% endif %}
+            </div>
+            <div class="form-group">
+                {{ form.start_date.label(class="form-label") }}
+                {{ form.start_date(class="form-input", type="date") }}
+                {% if form.start_date.errors %}
+                    {% for error in form.start_date.errors %}
                         <span class="text-danger">{{ error }}</span>
                     {% endfor %}
                 {% endif %}
             </div>
             <div class="form-group">
                 {{ form.location.label(class="form-label") }}
-                {{ form.location(class="form-input") }}
+                {{ form.location(class="form-input", placeholder="City Park Courts") }}
                 {% if form.location.errors %}
                     {% for error in form.location.errors %}
                         <span class="text-danger">{{ error }}</span>

--- a/pickaladder/templates/tournament/view.html
+++ b/pickaladder/templates/tournament/view.html
@@ -133,44 +133,46 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for p in participants %}
-                            <tr>
-                                <td data-label="Player">
-                                    <div style="display: flex; align-items: center; gap: 10px;">
-                                        <img src="{{ p.user | avatar_url }}" alt="Avatar" class="friend-avatar" style="width: 32px; height: 32px;" onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
-                                        <span>{{ p.display_name }}</span>
-                                    </div>
-                                </td>
-                                <td data-label="Status">
-                                    <span class="badge {{ 'badge-success' if p.status == 'accepted' else 'badge-warning' if p.status == 'pending' else 'badge-info' }}">
-                                        {{ 'Confirmed' if p.status == 'accepted' else 'Pending' if p.status == 'pending' else 'Invited (Email)' }}
-                                    </span>
-                                </td>
-                                <td data-label="Action">
-                                    {% if p.user.id == g.user.uid %}
-                                        {% if tournament.mode == 'DOUBLES' %}
-                                            {% if pending_partner_invite %}
-                                                <form action="{{ url_for('tournament.accept_team', tournament_id=tournament.id) }}" method="POST" style="display: inline;">
-                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                                    <button type="submit" class="btn btn-sm btn-success">Accept Team</button>
-                                                </form>
-                                            {% elif not team_status %}
-                                                <button type="button" class="btn btn-sm btn-success" onclick="openPartnerModal()">Join (Pick Partner)</button>
-                                            {% endif %}
-                                        {% else %}
-                                            {% if p.status == 'pending' %}
-                                                <form action="{{ url_for('tournament.join_tournament', tournament_id=tournament.id) }}" method="POST" style="display: inline;">
-                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                                    <button type="submit" class="btn btn-sm btn-success">Join</button>
-                                                </form>
+                            {% if participants %}
+                                {% for p in participants %}
+                                <tr>
+                                    <td data-label="Player">
+                                        <div style="display: flex; align-items: center; gap: 10px;">
+                                            <img src="{{ p.user | avatar_url }}" alt="Avatar" class="friend-avatar" style="width: 32px; height: 32px;" onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
+                                            <span>{{ p.display_name }}</span>
+                                        </div>
+                                    </td>
+                                    <td data-label="Status">
+                                        <span class="badge {{ 'badge-success' if p.status == 'accepted' else 'badge-warning' if p.status == 'pending' else 'badge-info' }}">
+                                            {{ 'Confirmed' if p.status == 'accepted' else 'Pending' if p.status == 'pending' else 'Invited (Email)' }}
+                                        </span>
+                                    </td>
+                                    <td data-label="Action">
+                                        {% if p.user.id == g.user.uid %}
+                                            {% if tournament.mode == 'DOUBLES' %}
+                                                {% if pending_partner_invite %}
+                                                    <form action="{{ url_for('tournament.accept_team', tournament_id=tournament.id) }}" method="POST" style="display: inline;">
+                                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                        <button type="submit" class="btn btn-sm btn-success">Accept Team</button>
+                                                    </form>
+                                                {% elif not team_status %}
+                                                    <button type="button" class="btn btn-sm btn-success" onclick="openPartnerModal()">Join (Pick Partner)</button>
+                                                {% endif %}
+                                            {% else %}
+                                                {% if p.status == 'pending' %}
+                                                    <form action="{{ url_for('tournament.join_tournament', tournament_id=tournament.id) }}" method="POST" style="display: inline;">
+                                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                        <button type="submit" class="btn btn-sm btn-success">Join</button>
+                                                    </form>
+                                                {% endif %}
                                             {% endif %}
                                         {% endif %}
-                                    {% endif %}
-                                </td>
-                            </tr>
+                                    </td>
+                                </tr>
+                                {% endfor %}
                             {% else %}
-                            <tr><td colspan="3" class="text-center">No participants yet.</td></tr>
-                            {% endfor %}
+                                <tr><td colspan="3" class="text-center">No participants yet.</td></tr>
+                            {% endif %}
                         </tbody>
                     </table>
                 </div>

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -5,6 +5,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='toggle.css') }}">
 {% endblock %}
 {% block content %}
+{% set onboarding_progress = onboarding_progress|default({'percent': 0, 'has_match': False, 'has_avatar': False, 'has_dupr': False, 'has_group': False, 'has_friend': False, 'has_rating': False}) %}
 <div id="dashboard-content">
     {# Section: Tournament Invites (Top Priority Alert Banner) #}
     {% if pending_tournament_invites %}
@@ -33,7 +34,7 @@
     {% endif %}
 
     {# Onboarding Quest Card replaces Performance Chart row during activation #}
-    {% if onboarding_progress.percent < 100 or not onboarding_progress.has_match %}
+    {% if onboarding_progress is defined and (onboarding_progress.percent < 100 or not onboarding_progress.has_match) %}
     <div class="card onboarding-card mb-4" style="border-left: 5px solid var(--accent-color);">
         <div class="card-body">
             <h4 class="mb-3">Welcome to pickaladder! 🚀 Let's get you ranked.</h4>
@@ -231,7 +232,7 @@
 
         {# Right Column: Competition Stack / Rookie Quest #}
         <div class="dashboard-column-right">
-            {% if not is_active %}
+        {% if not is_active|default(false) %}
             <div class="card rookie-quest-card">
                 <div class="card-header" style="border-bottom: none; margin-bottom: 0; padding-left: 0;">
                     <h3>Rookie Quest</h3>


### PR DESCRIPTION
I fixed several Jinja2 template errors. First, I addressed UndefinedErrors in `user_dashboard.html` by ensuring `onboarding_progress` has sensible defaults and defensive checks. Second, I fixed a TemplateSyntaxError in `tournament/view.html` by refactoring a `for...else` block into an `if...for...else` block, which is more robust in some Jinja2 environments. Finally, I updated `create_tournament.html` to include the missing `banner` field and used the correct `start_date` field, which was causing form validation and attribute errors in tournament creation tests. All relevant tests now pass.

Fixes #1115

---
*PR created automatically by Jules for task [280007125459939621](https://jules.google.com/task/280007125459939621) started by @brewmarsh*