### PR TITLE
Fix CSRF warnings by centralizing token handling in fetch interceptor

### DIFF
--- a/pickaladder/static/js/main.js
+++ b/pickaladder/static/js/main.js
@@ -1,3 +1,30 @@
+// Intercept fetch to add CSRF and Auth tokens
+(function () {
+    const originalFetch = window.fetch;
+    window.fetch = function (url, options) {
+        options = options || {};
+        options.headers = options.headers || {};
+
+        // Add CSRF token for non-safe methods
+        const method = (options.method || 'GET').toUpperCase();
+        const safeMethods = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];
+        if (!safeMethods.includes(method)) {
+            const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+            if (csrfMeta) {
+                options.headers['X-CSRFToken'] = csrfMeta.getAttribute('content');
+            }
+        }
+
+        // Add Firebase Auth token if available
+        const token = localStorage.getItem('firebaseIdToken');
+        if (token) {
+            options.headers['Authorization'] = 'Bearer ' + token;
+        }
+
+        return originalFetch(url, options);
+    };
+})();
+
 document.addEventListener('DOMContentLoaded', function () {
     // Handle form submissions with loading spinner
     const forms = document.querySelectorAll('form');

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
     <h1 class="mb-0">Community Hub</h1>
-    <button id="invite-friend-btn" class="btn btn-primary w-auto btn-action" data-csrf="{{ csrf_token() }}">
+    <button id="invite-friend-btn" class="btn btn-primary w-auto btn-action">
         <i class="fas fa-user-plus me-1"></i> Invite Friend
     </button>
 </div>
@@ -296,12 +296,10 @@
 
         if (inviteButton) {
             inviteButton.addEventListener('click', function () {
-                const csrfToken = this.getAttribute('data-csrf');
                 fetch("{{ url_for('user.create_invite') }}", {
                     method: "POST",
                     headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": csrfToken,
+                        "Content-Type": "application/json"
                     },
                 })
                     .then(response => response.json())
@@ -352,14 +350,12 @@
                 e.preventDefault();
                 const form = btn.closest('form');
                 const url = form.action;
-                const csrfToken = form.querySelector('input[name="csrf_token"]').value;
 
                 fetch(url, {
                     method: "POST",
                     headers: {
                         "X-Requested-With": "XMLHttpRequest",
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": csrfToken
+                        "Content-Type": "application/json"
                     },
                     body: JSON.stringify({})
                 })

--- a/pickaladder/templates/friends/index.html
+++ b/pickaladder/templates/friends/index.html
@@ -4,7 +4,7 @@
 <div class="page-header">
     <h1>Friends</h1>
     <div>
-        <button id="invite-friend-btn" class="btn" data-csrf="{{ csrf_token() }}">Invite a Friend</button>
+        <button id="invite-friend-btn" class="btn">Invite a Friend</button>
         <a href="{{ url_for('user.users') }}" class="btn">Find New Friends</a>
     </div>
 </div>
@@ -129,12 +129,10 @@
         ];
 
         inviteButton.addEventListener('click', function () {
-            const csrfToken = this.getAttribute('data-csrf');
             fetch("{{ url_for('user.create_invite') }}", {
                 method: "POST",
                 headers: {
-                    "Content-Type": "application/json",
-                    "X-CSRFToken": csrfToken,
+                    "Content-Type": "application/json"
                 },
             })
                 .then(response => response.json())

--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -216,17 +216,6 @@
             appId: "1:402457219675:web:a346e2dc0dfa732d31e57e",
             measurementId: "G-E28CXCXTSK"
         };
-        // Intercept fetch to add the auth token
-        const originalFetch = window.fetch;
-        window.fetch = function (url, options) {
-            const token = localStorage.getItem('firebaseIdToken');
-            if (token) {
-                options = options || {};
-                options.headers = options.headers || {};
-                options.headers['Authorization'] = 'Bearer ' + token;
-            }
-            return originalFetch(url, options);
-        };
 
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);

--- a/pickaladder/templates/login.html
+++ b/pickaladder/templates/login.html
@@ -90,8 +90,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 return fetch("{{ url_for('auth.session_login') }}", {
                     method: "POST",
                     headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                        "Content-Type": "application/json"
                     },
                     body: JSON.stringify({ idToken: idToken, remember: remember }),
                 });
@@ -128,8 +127,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 return fetch("{{ url_for('auth.session_login') }}", {
                     method: "POST",
                     headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                        "Content-Type": "application/json"
                     },
                     body: JSON.stringify({ idToken: idToken, remember: remember }),
                 });

--- a/pickaladder/templates/register.html
+++ b/pickaladder/templates/register.html
@@ -99,8 +99,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 return fetch("{{ url_for('auth.session_login') }}", {
                     method: "POST",
                     headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                        "Content-Type": "application/json"
                     },
                     body: JSON.stringify({ idToken: idToken }),
                 });

--- a/pickaladder/templates/user/profile.html
+++ b/pickaladder/templates/user/profile.html
@@ -48,8 +48,7 @@
 
                         {% if not is_friend and not friend_request_sent and user.id != profile_user.id %}
                         <button class="btn btn-volt btn-block mb-2" id="addFriendBtn"
-                            data-url="{{ url_for('user.send_friend_request', friend_id=profile_user.id) }}"
-                            data-csrf="{{ csrf_token() }}">Add Friend</button>
+                            data-url="{{ url_for('user.send_friend_request', friend_id=profile_user.id) }}">Add Friend</button>
                         {% elif friend_request_sent %}
                         <button class="btn btn-secondary btn-block mb-2" disabled>Friend Request Sent</button>
                         {% endif %}
@@ -174,13 +173,11 @@
         if (addFriendBtn) {
             addFriendBtn.addEventListener("click", (e) => {
                 const url = addFriendBtn.dataset.url;
-                const csrfToken = addFriendBtn.dataset.csrf;
                 fetch(url, {
                     method: "POST",
                     headers: {
                         "X-Requested-With": "XMLHttpRequest",
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": csrfToken
+                        "Content-Type": "application/json"
                     },
                     body: JSON.stringify({})
                 })

--- a/pickaladder/templates/users.html
+++ b/pickaladder/templates/users.html
@@ -114,7 +114,6 @@
 <script>
     document.addEventListener("DOMContentLoaded", () => {
         const addFriendBtns = document.querySelectorAll(".add-friend-btn");
-        const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
         addFriendBtns.forEach(btn => {
             btn.addEventListener("click", (e) => {
@@ -135,8 +134,7 @@
                     method: "POST",
                     headers: {
                         "X-Requested-With": "XMLHttpRequest",
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": csrfToken
+                        "Content-Type": "application/json"
                     },
                     body: JSON.stringify({})
                 })


### PR DESCRIPTION
I have centralized the handling of CSRF tokens for AJAX requests. Instead of manually adding the `X-CSRFToken` header to every `fetch()` call, I implemented a global interceptor in `pickaladder/static/js/main.js`. This interceptor automatically attaches the CSRF token (from the meta tag) to any non-safe request (POST, PUT, DELETE, PATCH). It also handles the Firebase Authorization token, which was previously handled by a separate interceptor in `layout.html`. I've removed the redundant code and cleaned up manual header additions in various templates to improve maintainability and ensure consistent security across the application.

Fixes #1143

---
*PR created automatically by Jules for task [3901715490739456805](https://jules.google.com/task/3901715490739456805) started by @brewmarsh*