### PR TITLE
Fix CI lint errors (E501)

### DIFF
--- a/pickaladder/tournament/services.py
+++ b/pickaladder/tournament/services.py
@@ -432,7 +432,12 @@ class TournamentService:
             raise PermissionError("Unauthorized")
 
         # Optional: check if matches exist before deleting
-        # matches = db.collection("matches").where("tournamentId", "==", tournament_id).limit(1).stream()
+        # matches = (
+        #     db.collection("matches")
+        #     .where("tournamentId", "==", tournament_id)
+        #     .limit(1)
+        #     .stream()
+        # )
         # if any(matches):
         #     raise ValueError("Cannot delete tournament with matches recorded.")
 

--- a/pickaladder/user/services/profile.py
+++ b/pickaladder/user/services/profile.py
@@ -56,12 +56,18 @@ def update_email_address(
             current_app.logger.error(f"Email error updating email: {e}")
             return (
                 True,
-                "Your email has been updated in our records, but we couldn't send a verification email. Please contact support.",
+                (
+                    "Your email has been updated in our records, but we couldn't "
+                    "send a verification email. Please contact support."
+                ),
             )
 
         return (
             True,
-            "Your email has been updated. Please check your new email address to verify it.",
+            (
+                "Your email has been updated. Please check your new email "
+                "address to verify it."
+            ),
         )
     except auth.EmailAlreadyExistsError:
         return False, "That email address is already in use."

--- a/scripts/sync_db.py
+++ b/scripts/sync_db.py
@@ -49,7 +49,9 @@ class BatchProcessor:
 
 
 def initialize_apps() -> tuple[firebase_admin.App, firebase_admin.App]:
-    """Initializes the two Firebase apps for Production (Source) and Beta (Destination)."""
+    """
+    Initializes the two Firebase apps for Production (Source) and Beta (Destination).
+    """
     prod_key_path = os.environ.get("PROD_KEY_PATH")
     beta_key_path = os.environ.get("BETA_KEY_PATH")
 
@@ -73,7 +75,10 @@ def initialize_apps() -> tuple[firebase_admin.App, firebase_admin.App]:
 def delete_collection_recursive(
     coll_ref: CollectionReference, batch_processor: BatchProcessor
 ) -> None:
-    """Recursively adds all documents in a collection and its subcollections to the delete batch."""
+    """
+    Recursively adds all documents in a collection and its subcollections
+    to the delete batch.
+    """
     for doc_ref in coll_ref.list_documents():
         # Recursively handle subcollections
         for sub_coll in doc_ref.collections():
@@ -86,7 +91,10 @@ def copy_collection_recursive(
     dest_coll: CollectionReference,
     batch_processor: BatchProcessor,
 ) -> int:
-    """Recursively copies all documents from one collection to another using batching."""
+    """
+    Recursively copies all documents from one collection to another
+    using batching.
+    """
     count = 0
     for doc_snap in src_coll.stream():
         data = doc_snap.to_dict()


### PR DESCRIPTION
This PR fixes 6 linting errors (E501 Line too long) across three files to resolve CI failures.

Changes:
- `pickaladder/tournament/services.py`: Wrapped a long commented-out Firestore query.
- `pickaladder/user/services/profile.py`: Broke long return strings using parentheses and implicit concatenation.
- `scripts/sync_db.py`: Re-formatted long docstrings into a multi-line format.

All changes adhere to the 88-character limit and avoid using backslashes for line continuation. All tests passed.

Fixes #1192

---
*PR created automatically by Jules for task [16219469922636984954](https://jules.google.com/task/16219469922636984954) started by @brewmarsh*