### PR TITLE
Standardize Toast Formatting and Positioning

### DIFF
--- a/pickaladder/static/css/cards.css
+++ b/pickaladder/static/css/cards.css
@@ -84,19 +84,22 @@
 /* Toasts */
 .toast-container {
     position: fixed;
-    top: 20px;
+    top: 60px;
     right: 20px;
-    z-index: 1050;
+    z-index: 2000;
     min-width: 300px;
 }
 .toast {
     background-color: var(--card-bg);
     color: var(--text-primary);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    border-radius: 8px;
+    box-shadow: var(--shadow-lg);
+    border-radius: var(--radius-md);
+    border: none;
     overflow: hidden;
     margin-bottom: 10px;
     position: relative;
+    max-width: 350px;
+    width: 100%;
 }
 .toast::before {
     content: '';
@@ -106,8 +109,16 @@
     bottom: 0;
     width: 6px;
     background-color: var(--primary-color);
+    z-index: 1;
 }
-.toast-body { padding: 15px 20px; }
+.toast-header {
+    background: transparent;
+    border-bottom: none;
+    padding: 12px 16px 0 20px;
+}
+.toast-body {
+    padding: 8px 20px 16px 20px;
+}
 
 /* Social Share Card */
 .social-share-card {

--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -52,6 +52,35 @@
     {% endif %}
     {% include 'navbar.html' %}
 
+    <div class="toast-container">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% for category, message in messages %}
+        <div class="toast alert-{{ category }} show" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+                <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2" alt="Logo"
+                    style="width: 20px; height: 20px;">
+                <strong class="mr-auto">pickaladder</strong>
+                <button type="button" class="ml-2 mb-1 close" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="toast-body">
+                {{ message }}
+            </div>
+        </div>
+        {% endfor %}
+        {% endwith %}
+    </div>
+
+    {% if session.get('show_welcome_invites') %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const count = {{ session.pop('show_welcome_invites') }};
+            showToast(`Welcome to Pickaladder! You have ${count} tournament invites waiting for you on your dashboard!`, 'success');
+        });
+    </script>
+    {% endif %}
+
     {% if global_announcement and global_announcement.is_active %}
     <div class="container mt-3">
         <div class="alert alert-{{ global_announcement.level }} alert-dismissible fade show" role="alert">
@@ -65,35 +94,6 @@
 
     <div class="container">
         <main class="main-content">
-            {% if session.get('show_welcome_invites') %}
-            <script>
-                document.addEventListener('DOMContentLoaded', function () {
-                    const count = {{ session.pop('show_welcome_invites') }};
-                    showToast(`Welcome to Pickaladder! You have ${count} tournament invites waiting for you on your dashboard!`, 'success');
-                });
-            </script>
-            {% endif %}
-            {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-            <div class="toast-container">
-                {% for category, message in messages %}
-                <div class="toast alert-{{ category }} show" role="alert" aria-live="assertive" aria-atomic="true">
-                    <div class="toast-header">
-                        <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2"
-                            alt="Logo" style="width: 20px; height: 20px;">
-                        <strong class="mr-auto">pickaladder</strong>
-                        <button type="button" class="ml-2 mb-1 close" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="toast-body">
-                        {{ message }}
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-            {% endif %}
-            {% endwith %}
             {% block content %}{% endblock %}
         </main>
     </div>


### PR DESCRIPTION
This change improves the user experience by fixing toast notifications (flash messages) that were previously clipped at the top of the screen or hidden behind the navigation bar. 

Key changes include:
1.  **Repositioning:** Moved the toast container from within the main content block to the top level of the `<body>` tag.
2.  **Styling Updates:** Increased the `top` offset to `60px` (to sit below the navbar) and bumped the `z-index` to `2000`.
3.  **Visual Cleanup:** Standardized toast width to `350px`, added a deeper shadow, and simplified the header styling to create a modern, "floating alert" look.
4.  **Robustness:** Ensured the toast container is always available in the DOM so that JavaScript-driven toasts (like onboarding notifications) always have a target to render into.

Verified via Playwright screenshots and existing unit tests.

Fixes #1194

---
*PR created automatically by Jules for task [4976543268936556932](https://jules.google.com/task/4976543268936556932) started by @brewmarsh*