### PR TITLE
Fix broken profile image and improve avatar fallback logic

### DIFF
--- a/pickaladder/__init__.py
+++ b/pickaladder/__init__.py
@@ -240,13 +240,18 @@ def _register_template_utilities(app: Flask) -> None:
     app.template_filter("display_name")(smart_display_name)
 
     @app.template_filter("avatar_url")
-    def avatar_url_filter(user: dict[str, Any]) -> str:
+    def avatar_url_filter(user: Any) -> str:
         """Return the avatar URL for a user."""
         if not user:
             return ""
+
+        # Handle AnonymousUserMixin or other non-dict objects
+        if hasattr(user, "is_anonymous") and user.is_anonymous:
+            return "https://api.dicebear.com/9.x/avataaars/svg?seed=Guest"
+
         wrapped = wrap_user(user)
         url = wrapped.avatar_url if wrapped else ""
-        if url == "default":
+        if not url or url == "default":
             # Fallback to DiceBear Avatars (avataaars style)
             seed = user.get("username") or user.get("email") or "User"
             return f"https://api.dicebear.com/9.x/avataaars/svg?seed={seed}"

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -62,7 +62,7 @@
                 {% if g.user %}
                 <div class="dropdown">
                     <button class="dropbtn">
-                        <img src="{{ g.user.avatar_url }}" alt="Profile Picture" class="avatar avatar-sm"
+                        <img src="{{ g.user | avatar_url }}" alt="Profile Picture" class="avatar avatar-sm"
                             onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
                     </button>
                     <div class="dropdown-content">

--- a/pickaladder/templates/user/settings.html
+++ b/pickaladder/templates/user/settings.html
@@ -13,7 +13,7 @@
                     {{ form.hidden_tag() }}
 
                     <div class="text-center mb-4">
-                        <img src="{{ current_user.avatar_url }}" alt="Profile Picture" class="avatar avatar-xl mb-2" id="avatar-preview">
+                        <img src="{{ current_user | avatar_url }}" alt="Profile Picture" class="avatar avatar-xl mb-2" id="avatar-preview">
                         <div class="form-group mt-2">
                             {{ form.profile_picture.label }}
                             {{ form.profile_picture(class="form-control-file") }}

--- a/pickaladder/user/services/profile.py
+++ b/pickaladder/user/services/profile.py
@@ -72,6 +72,9 @@ def update_email_address(
 
 def upload_profile_picture(user_id: str, file_storage: FileStorage) -> str | None:
     """Upload a profile picture to Firebase Storage and return the public URL."""
+    if not file_storage or not getattr(file_storage, "filename", None):
+        return None
+
     try:
         filename = secure_filename(file_storage.filename or "profile.jpg")
         bucket = storage.bucket()


### PR DESCRIPTION
This PR fixes the issue where profile pictures appear as broken icons. It centralizes the avatar fallback logic in the `avatar_url` Jinja filter and ensures it's used in key templates like the settings page and navbar. It also adds a defensive check to the profile picture upload service to prevent invalid Firestore updates.

Fixes #1193

---
*PR created automatically by Jules for task [9751341990099744273](https://jules.google.com/task/9751341990099744273) started by @brewmarsh*