### PR TITLE
Fix avatar display after upload and ensure session refresh

### DIFF
--- a/pickaladder/user/services/core.py
+++ b/pickaladder/user/services/core.py
@@ -231,7 +231,9 @@ def update_settings(
             )
             if success:
                 # Refresh current_user_data even on email change
-                if current_user_data is not None and hasattr(current_user_data, "update"):
+                if current_user_data is not None and hasattr(
+                    current_user_data, "update"
+                ):
                     current_user_data.update(update_data)
                 return {"success": True, "info": message}
             return {"success": False, "error": message}

--- a/pickaladder/user/services/profile.py
+++ b/pickaladder/user/services/profile.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import tempfile
 from typing import TYPE_CHECKING, Any
 
 from firebase_admin import auth, storage

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -174,7 +174,7 @@ class UserRoutesFirebaseTestCase(unittest.TestCase):
         self.assertIn(b"Settings updated!", response.data)
         self.mock_storage_service.bucket.assert_called()
         mock_bucket.blob.assert_called_with(f"profile_pictures/{MOCK_USER_ID}/test.png")
-        mock_blob.upload_from_filename.assert_called()
+        mock_blob.upload_from_file.assert_called()
         mock_blob.make_public.assert_called()
 
     def test_update_dupr_and_dark_mode(self) -> None:


### PR DESCRIPTION
This change fixes a bug where newly uploaded profile pictures were not being displayed correctly in the UI. The root causes were identified as:
1. Stale in-memory user state (g.user) not reflecting the new profilePictureUrl within the same request.
2. Stale `profilePictureThumbnailUrl` in Firestore taking precedence over the new `profilePictureUrl` in the `avatar_url` logic.
3. Inefficient upload flow using temporary files.

The fix involves updating the `current_user_data` dictionary after successful Firestore writes, clearing the thumbnail URL when a new avatar is uploaded, and simplifying the upload process using `blob.upload_from_file`.

Fixes #1198

---
*PR created automatically by Jules for task [10921174447035721881](https://jules.google.com/task/10921174447035721881) started by @brewmarsh*