### PR TITLE
Improve static analysis and type safety in test suite

### DIFF
--- a/tests/e2e/test_mobile_design.py
+++ b/tests/e2e/test_mobile_design.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
-from playwright.sync_api import expect
+from playwright.sync_api import Page, expect
 
 
 @pytest.fixture
-def seeded_data(mock_db):
+def seeded_data(mock_db: Any) -> str:
     # Clear and seed data
     mock_db._data = {}
 
     # Create a user
-    user_id = "testuser"
-    user_data = {
+    user_id: str = "testuser"
+    user_data: dict[str, Any] = {
         "uid": user_id,
         "username": "testuser",
         "email": "testuser@example.com",
@@ -21,8 +25,8 @@ def seeded_data(mock_db):
     mock_db.collection("users").document(user_id).set(user_data)
 
     # Create a group
-    group_id = "group1"
-    group_data = {
+    group_id: str = "group1"
+    group_data: dict[str, Any] = {
         "name": "Pickleball Pros",
         "description": "A group for pros",
         "ownerRef": mock_db.collection("users").document(user_id),
@@ -43,8 +47,8 @@ def seeded_data(mock_db):
     )
 
     # Create a tournament
-    tournament_id = "tourney1"
-    tournament_data = {
+    tournament_id: str = "tourney1"
+    tournament_data: dict[str, Any] = {
         "name": "Summer Open",
         "date": "2023-07-01",
         "location": "Central Park",
@@ -57,7 +61,9 @@ def seeded_data(mock_db):
     return user_id
 
 
-def test_mobile_layout(page_with_firebase, app_server, seeded_data):
+def test_mobile_layout(
+    page_with_firebase: Page, app_server: str, seeded_data: str
+) -> None:
     page = page_with_firebase
     # 1. Login
     page.goto(f"{app_server}/auth/login")

--- a/tests/e2e/verify_fixes.py
+++ b/tests/e2e/verify_fixes.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import os
 import re
+from typing import Any
 
-from playwright.sync_api import expect
+from playwright.sync_api import Page, expect
 
 
-def test_verify_fixes(app_server, page_with_firebase, mock_db):
+def test_verify_fixes(app_server: str, page_with_firebase: Page, mock_db: Any) -> None:
     page = page_with_firebase
     base_url = app_server
 
@@ -39,7 +42,7 @@ def test_verify_fixes(app_server, page_with_firebase, mock_db):
     page.click("button:has-text('Share')")
     page.wait_for_selector("#shareGroupModal.show", timeout=5000)
 
-    stat_text = page.locator(".social-share-card-stat").text_content()
+    stat_text: str | None = page.locator(".social-share-card-stat").text_content()
     print(f"Stat text: {stat_text}")
     # Since it's a new group, rank is Member or something.
     # In group.html:

--- a/tests/test_config_integrity.py
+++ b/tests/test_config_integrity.py
@@ -1,6 +1,9 @@
 """Test to ensure configuration integrity, specifically for Firebase mocking."""
 
+from __future__ import annotations
+
 import unittest
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import firebase_admin
@@ -12,7 +15,10 @@ from pickaladder import create_app
 class TestConfigIntegrity(unittest.TestCase):
     """Test case for configuration integrity."""
 
-    def setUp(self):
+    mock_initialize_app: MagicMock
+    mock_firestore_client: MagicMock
+
+    def setUp(self) -> None:
         self.mock_initialize_app = patch("firebase_admin.initialize_app").start()
         self.mock_firestore_client = patch("firebase_admin.firestore.client").start()
         self.addCleanup(patch.stopall)
@@ -26,7 +32,7 @@ class TestConfigIntegrity(unittest.TestCase):
         with app.app_context():
             # Explicitly call firestore.client()
             # If the app is misconfigured for testing, this will raise a ValueError.
-            client = firebase_admin.firestore.client()
+            client: Any = firebase_admin.firestore.client()
 
             # Assert: It should not be a ValueError (implicitly handled if it reaches)
             # Assert: It should return a Mock object or a MockFirestore object.

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -1,7 +1,13 @@
 """Tests for the user impersonation feature."""
 
+from __future__ import annotations
+
 import unittest
+from typing import Any
 from unittest.mock import MagicMock, patch
+
+from flask import Flask
+from flask.testing import FlaskClient
 
 from pickaladder import create_app
 
@@ -9,7 +15,16 @@ from pickaladder import create_app
 class ImpersonationTestCase(unittest.TestCase):
     """Test case for user impersonation."""
 
-    def setUp(self):
+    mock_firestore: MagicMock
+    mock_firebase_admin: MagicMock
+    app: Flask
+    client: FlaskClient
+    app_context: Any
+    admin_data: dict[str, Any]
+    user_data: dict[str, Any]
+    db: MagicMock
+
+    def setUp(self) -> None:
         """Set up a test client and mock environment."""
         self.mock_firestore = patch("pickaladder.firestore.client").start()
         self.mock_firebase_admin = patch("firebase_admin.initialize_app").start()
@@ -41,13 +56,13 @@ class ImpersonationTestCase(unittest.TestCase):
         # Setup mock db
         self.db = self.mock_firestore.return_value
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         patch.stopall()
         self.app_context.pop()
 
-    def _mock_user_get(self, user_id, user_data):
-        doc_ref = MagicMock()
-        doc_snapshot = MagicMock()
+    def _mock_user_get(self, user_id: str, user_data: dict[str, Any]) -> None:
+        doc_ref: MagicMock = MagicMock()
+        doc_snapshot: MagicMock = MagicMock()
         doc_snapshot.exists = True
         doc_snapshot.to_dict.return_value = user_data
         doc_ref.get.return_value = doc_snapshot
@@ -57,7 +72,7 @@ class ImpersonationTestCase(unittest.TestCase):
             doc_ref if uid == user_id else MagicMock()
         )
 
-    def test_impersonation_flow(self):
+    def test_impersonation_flow(self) -> None:
         """Test the full impersonation flow: start, verify, stop."""
 
         # 1. Login as Admin
@@ -77,14 +92,14 @@ class ImpersonationTestCase(unittest.TestCase):
 
         # 2. Start Impersonation of user1
         # Mock getting user1 data for the redirect flash message
-        doc_ref_user1 = MagicMock()
-        doc_snapshot_user1 = MagicMock()
+        doc_ref_user1: MagicMock = MagicMock()
+        doc_snapshot_user1: MagicMock = MagicMock()
         doc_snapshot_user1.exists = True
         doc_snapshot_user1.to_dict.return_value = self.user_data
         doc_ref_user1.get.return_value = doc_snapshot_user1
 
         # We need to handle both admin1 and user1 lookups
-        def document_side_effect(uid):
+        def document_side_effect(uid: str) -> MagicMock:
             if uid == "admin1":
                 doc = MagicMock()
                 snap = MagicMock()
@@ -108,7 +123,7 @@ class ImpersonationTestCase(unittest.TestCase):
         # This is hard to check directly via client.get as it clears g between requests
         # but we can check if the response contains the impersonated user's name
         # or the banner.
-        data = response.data.decode("utf-8")
+        data: str = response.data.decode("utf-8")
         self.assertIn("You are now impersonating User", data)
         self.assertIn("You are impersonating <strong>User</strong>", data)
 
@@ -121,7 +136,7 @@ class ImpersonationTestCase(unittest.TestCase):
 
         self.assertIn(b"Welcome back, Admin", response.data)
 
-    def test_non_admin_cannot_impersonate(self):
+    def test_non_admin_cannot_impersonate(self) -> None:
         """Ensure non-admins cannot start impersonation."""
         with self.client.session_transaction() as sess:
             sess["user_id"] = "user2"

--- a/tests/test_rematch_logic.py
+++ b/tests/test_rematch_logic.py
@@ -1,13 +1,23 @@
 """Tests for the rematch logic in match recording."""
 
+from __future__ import annotations
+
 import unittest
+from typing import Any
 from unittest.mock import MagicMock, patch
+
+from flask import Flask
+from flask.testing import FlaskClient
 
 from pickaladder import create_app
 
 
 class RematchLogicTestCase(unittest.TestCase):
-    def setUp(self):
+    app: Flask
+    client: FlaskClient
+    app_context: Any
+
+    def setUp(self) -> None:
         self.app = create_app(
             {
                 "TESTING": True,
@@ -19,22 +29,22 @@ class RematchLogicTestCase(unittest.TestCase):
         self.app_context = self.app.app_context()
         self.app_context.push()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.app_context.pop()
 
     @patch("pickaladder.match.routes.firestore.client")
     @patch("pickaladder.match.routes.MatchQueryService.get_candidate_player_ids")
     def test_record_match_prepopulation(
-        self, mock_get_candidates, mock_firestore_client
-    ):
+        self, mock_get_candidates: MagicMock, mock_firestore_client: MagicMock
+    ) -> None:
         # Mocking necessary parts for the record_match route
         mock_get_candidates.return_value = {"user1", "user2", "user3", "user4"}
 
         # Mock firestore client for choices population
-        mock_db = MagicMock()
+        mock_db: MagicMock = MagicMock()
         mock_firestore_client.return_value = mock_db
 
-        def mock_get_all(refs):
+        def mock_get_all(refs: list[Any]) -> list[MagicMock]:
             docs = []
             for ref in refs:
                 doc = MagicMock()
@@ -62,7 +72,7 @@ class RematchLogicTestCase(unittest.TestCase):
             )
 
             self.assertEqual(response.status_code, 200)
-            data = response.data.decode("utf-8")
+            data: str = response.data.decode("utf-8")
 
             # Use more flexible checks
             self.assertTrue('value="doubles"' in data and "selected" in data)


### PR DESCRIPTION
I have improved the static analysis and type safety of the test suite by adding comprehensive PEP 484 type hints to five targeted test files. 

Key changes include:
- Integration of `from __future__ import annotations` to support modern Python type syntax.
- Explicit return types for all test methods (`-> None`).
- Proper typing for class-level and instance variables in `unittest.TestCase` classes.
- Standardized typing for Firestore payloads (`dict[str, Any]`) and mock objects (`MagicMock`).
- Updated E2E test signatures with `Page` and `MagicMock` where appropriate.

Verification:
- All updated tests were executed using `uv run pytest` and all 6 tests passed successfully.
- Code review confirmed adherence to guidelines and absence of runtime logic changes.

Fixes #1205

---
*PR created automatically by Jules for task [9649841270177879072](https://jules.google.com/task/9649841270177879072) started by @brewmarsh*