### PR TITLE
Expand profile menu hover hitboxes

### DIFF
--- a/pickaladder/static/css/layout.css
+++ b/pickaladder/static/css/layout.css
@@ -66,6 +66,58 @@ body {
     gap: 15px;
 }
 
+/* Dropdown Styles */
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropbtn {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    border-radius: 50%;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    right: 0;
+    background-color: var(--card-bg);
+    min-width: 220px;
+    box-shadow: var(--shadow-lg);
+    z-index: 1000;
+    border-radius: var(--radius-md);
+    padding: 0;
+    overflow: hidden;
+}
+
+.dropdown-content a {
+    color: var(--text-primary);
+    padding: 12px 16px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    font-size: 14px;
+    transition: background-color 0.2s;
+}
+
+.dropdown-content a:hover {
+    background-color: var(--bg-color);
+}
+
+.dropdown-divider {
+    height: 1px;
+    margin: 4px 0;
+    overflow: hidden;
+    background-color: var(--border-color);
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
 .desktop-auth-buttons {
     display: flex;
     gap: 10px;

--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -319,54 +319,6 @@ select:focus {
     font-size: 14px;
 }
 
-/* Dropdown */
-.dropdown {
-    position: relative;
-    display: inline-block;
-}
-
-.dropbtn {
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    border-radius: 50%;
-}
-
-.dropdown-content {
-    display: none;
-    position: absolute;
-    right: 0;
-    background-color: var(--card-bg);
-    min-width: 220px;
-    box-shadow: var(--box-shadow);
-    z-index: 1;
-    border-radius: var(--border-radius);
-    padding: 8px 0;
-}
-
-.dropdown-content a {
-    color: var(--text-primary);
-    padding: 10px 20px;
-    text-decoration: none;
-    display: block;
-    font-size: 14px;
-}
-
-.dropdown-content a:hover {
-    background-color: var(--bg-color);
-}
-
-.dropdown-divider {
-    height: 1px;
-    margin: 8px 0;
-    overflow: hidden;
-    background-color: var(--border-color);
-}
-
-.dropdown:hover .dropdown-content {
-    display: block;
-}
 
 /* Cards & Layouts */
 .card {
@@ -756,10 +708,6 @@ select:focus {
     /* Lighter lime for better contrast on dark backgrounds */
 }
 
-/* Fixes for dark mode visibility issues */
-[data-theme="dark"] .dropdown-content a:hover {
-    background-color: var(--bg-color);
-}
 
 [data-theme="dark"] .alert-danger {
     color: #f8d7da;


### PR DESCRIPTION
This change improves the usability of the user dropdown menu by expanding the hitboxes of the menu items. Previously, the clickable area might have been limited to the text or icon. Now, the entire row is clickable and hoverable.

Key changes:
- Moved all dropdown-related CSS from the legacy `dark.css` to the modular `layout.css`.
- Implemented a full-width hitbox strategy: `padding: 0` on the container and `padding: 12px 16px` on the `<a>` tags.
- Used `display: flex` for `<a>` tags to ensure they fill the width and align content properly.
- Added `overflow: hidden` to `.dropdown-content` to keep hover backgrounds within rounded corners.
- Standardized variables for radius and shadows where appropriate.

Fixes #1219

---
*PR created automatically by Jules for task [8419023309524057134](https://jules.google.com/task/8419023309524057134) started by @brewmarsh*