### PR TITLE
Refactor Group domain for lower ACL

### DIFF
--- a/pickaladder/group/routes.py
+++ b/pickaladder/group/routes.py
@@ -54,14 +54,60 @@ def view_groups() -> Any:
     )
 
 
+def _handle_referrer() -> None:
+    """Capture referrer ID from request arguments into session."""
+    if "ref" in request.args:
+        session["referrer_id"] = request.args.get("ref")
+
+
+def _handle_invite_friend_form(
+    db: Any, group_id: str, context: dict[str, Any]
+) -> tuple[InviteFriendForm, Any | None]:
+    """Process InviteFriendForm submission."""
+    form = InviteFriendForm()
+    form.friend.choices = [
+        (friend.id, friend.to_dict().get("name", friend.id))
+        for friend in context["eligible_friends"]
+    ]
+
+    if form.validate_on_submit() and "friend" in request.form:
+        try:
+            GroupService.invite_friend(db, group_id, form.friend.data)
+            flash("Friend invited successfully.", "success")
+            return form, redirect(url_for(".view_group", group_id=group_id))
+        except Exception as e:
+            flash(f"An unexpected error occurred: {e}", "danger")
+    return form, None
+
+
+def _handle_invite_email_form(
+    db: Any, group_id: str, group_name: str
+) -> tuple[InviteByEmailForm, Any | None]:
+    """Process InviteByEmailForm submission."""
+    invite_email_form = InviteByEmailForm()
+    if invite_email_form.validate_on_submit() and "email" in request.form:
+        try:
+            name = invite_email_form.name.data or "Friend"
+            email = invite_email_form.email.data
+            if email:
+                GroupService.invite_by_email(
+                    db, group_id, group_name, email, name, g.user["uid"]
+                )
+                flash(f"Invitation is being sent to {email.lower()}.", "success")
+                return invite_email_form, redirect(
+                    url_for(".view_group", group_id=group_id)
+                )
+        except Exception as e:
+            flash(f"An error occurred creating the invitation: {e}", "danger")
+    return invite_email_form, None
+
+
 # TODO: Add type hints for Agent clarity
 @bp.route("/<string:group_id>", methods=["GET", "POST"])
 @login_required
 def view_group(group_id: str) -> Any:
     """Display a single group's page."""
-    # Capture Referrer
-    if "ref" in request.args:
-        session["referrer_id"] = request.args.get("ref")
+    _handle_referrer()
 
     db = firestore.client()
     player_a_id = request.args.get("playerA")
@@ -78,40 +124,18 @@ def view_group(group_id: str) -> Any:
         flash("You do not have permission to access this group.", "danger")
         return redirect(url_for(".view_groups"))
 
-    # Handle Forms
-    form = InviteFriendForm()
-    form.friend.choices = [
-        (friend.id, friend.to_dict().get("name", friend.id))
-        for friend in context["eligible_friends"]
-    ]
+    form, resp = _handle_invite_friend_form(db, group_id, context)
+    if resp:
+        return resp
 
-    if form.validate_on_submit() and "friend" in request.form:
-        try:
-            GroupService.invite_friend(db, group_id, form.friend.data)
-            flash("Friend invited successfully.", "success")
-            return redirect(url_for(".view_group", group_id=group_id))
-        except Exception as e:
-            flash(f"An unexpected error occurred: {e}", "danger")
-
-    invite_email_form = InviteByEmailForm()
-    if invite_email_form.validate_on_submit() and "email" in request.form:
-        try:
-            name = invite_email_form.name.data or "Friend"
-            email = invite_email_form.email.data
-            if email:
-                GroupService.invite_by_email(
-                    db, group_id, context["group"]["name"], email, name, g.user["uid"]
-                )
-                flash(f"Invitation is being sent to {email.lower()}.", "success")
-                return redirect(url_for(".view_group", group_id=group_id))
-        except Exception as e:
-            flash(f"An error occurred creating the invitation: {e}", "danger")
+    invite_email_form, resp = _handle_invite_email_form(
+        db, group_id, context["group"]["name"]
+    )
+    if resp:
+        return resp
 
     return render_template(
-        "group.html",
-        form=form,
-        invite_email_form=invite_email_form,
-        **context,
+        "group.html", form=form, invite_email_form=invite_email_form, **context
     )
 
 
@@ -134,25 +158,26 @@ def create_group() -> Any:
     return render_template("create_group.html", form=form)
 
 
-# TODO: Add type hints for Agent clarity
-@bp.route("/<string:group_id>/edit", methods=["GET", "POST"])
-@login_required
-def edit_group(group_id: str) -> Any:
-    """Edit a group."""
-    db = firestore.client()
+def _get_group_for_edit(db: Any, group_id: str) -> dict[str, Any]:
+    """Fetch group and verify admin permissions."""
     group_ref = db.collection("groups").document(group_id)
     group = group_ref.get()
     if not group.exists:
-        flash("Group not found.", "danger")
-        return redirect(url_for(".view_groups"))
+        raise GroupNotFound("Group not found.")
 
     group_data = group.to_dict()
     group_data["id"] = group.id
 
     if not GroupService.is_group_admin(group_data, g.user["uid"]):
-        flash("You do not have permission to edit this group.", "danger")
-        return redirect(url_for(".view_group", group_id=group_id))
+        raise AccessDenied("You do not have permission to edit this group.")
 
+    return group_data
+
+
+def _handle_edit_group_form(
+    db: Any, group_id: str, group_data: dict[str, Any]
+) -> tuple[GroupForm, Any | None]:
+    """Process GroupForm submission for editing."""
     form = GroupForm(data=group_data)
     if form.validate_on_submit():
         try:
@@ -160,15 +185,36 @@ def edit_group(group_id: str) -> Any:
                 db, group_id, g.user["uid"], form.data, form.profile_picture.data
             )
             flash("Group updated successfully.", "success")
-            return redirect(url_for(".view_group", group_id=group.id))
+            return form, redirect(url_for(".view_group", group_id=group_id))
         except AccessDenied:
             flash("You do not have permission to edit this group.", "danger")
-            return redirect(url_for(".view_group", group_id=group.id))
+            return form, redirect(url_for(".view_group", group_id=group_id))
         except Exception as e:
             flash(f"An unexpected error occurred: {e}", "danger")
+    return form, None
+
+
+# TODO: Add type hints for Agent clarity
+@bp.route("/<string:group_id>/edit", methods=["GET", "POST"])
+@login_required
+def edit_group(group_id: str) -> Any:
+    """Edit a group."""
+    db = firestore.client()
+    try:
+        group_data = _get_group_for_edit(db, group_id)
+    except GroupNotFound:
+        flash("Group not found.", "danger")
+        return redirect(url_for(".view_groups"))
+    except AccessDenied as e:
+        flash(str(e), "danger")
+        return redirect(url_for(".view_group", group_id=group_id))
+
+    form, resp = _handle_edit_group_form(db, group_id, group_data)
+    if resp:
+        return resp
 
     return render_template(
-        "edit_group.html", form=form, group=group_data, group_id=group.id
+        "edit_group.html", form=form, group=group_data, group_id=group_id
     )
 
 
@@ -475,6 +521,3 @@ def get_user_group_trend(group_id: str, user_id: str) -> Any:
         "labels": trend_data["labels"],
         "dataset": user_dataset,
     }
-
-
-# Force change

--- a/pickaladder/group/services/match_parser.py
+++ b/pickaladder/group/services/match_parser.py
@@ -5,6 +5,17 @@ from __future__ import annotations
 from typing import Any
 
 
+def _extract_id(val: Any) -> str | None:
+    """Extract an ID from a Firestore reference, dictionary, or string."""
+    if hasattr(val, "id"):
+        return val.id
+    if isinstance(val, dict) and "id" in val:
+        return val["id"]
+    if isinstance(val, str):
+        return val
+    return None
+
+
 def _resolve_team_ids(
     data: dict[str, Any], team_key: str, player_prefix: str, partner_prefix: str
 ) -> set[str]:
@@ -13,17 +24,32 @@ def _resolve_team_ids(
 
     # 1. Handle list of refs, dicts, or strings in the team_key field
     # (e.g., 'team1', 'team2')
+    team_ids.update(_resolve_from_team_key(data, team_key))
+
+    # 2. Check individual fields for the team
+    team_ids.update(
+        _resolve_from_individual_fields(data, team_key, player_prefix, partner_prefix)
+    )
+
+    return team_ids
+
+
+def _resolve_from_team_key(data: dict[str, Any], team_key: str) -> set[str]:
+    """Resolve IDs from the team_key field if it's a list."""
+    team_ids = set()
     team_data = data.get(team_key)
     if isinstance(team_data, list):
         for r in team_data:
-            if hasattr(r, "id"):
-                team_ids.add(r.id)
-            elif isinstance(r, dict) and "id" in r:
-                team_ids.add(r["id"])
-            elif isinstance(r, str):
-                team_ids.add(r)
+            if val_id := _extract_id(r):
+                team_ids.add(val_id)
+    return team_ids
 
-    # 2. Check individual fields for the team
+
+def _resolve_from_individual_fields(
+    data: dict[str, Any], team_key: str, player_prefix: str, partner_prefix: str
+) -> set[str]:
+    """Resolve IDs from individual player and team fields."""
+    team_ids = set()
     fields = [
         f"{player_prefix}Ref",
         f"{partner_prefix}Ref",
@@ -32,15 +58,8 @@ def _resolve_team_ids(
         f"{team_key}Ref",
     ]
     for field in fields:
-        val = data.get(field)
-        if val:
-            if hasattr(val, "id"):
-                team_ids.add(val.id)
-            elif isinstance(val, dict) and "id" in val:
-                team_ids.add(val["id"])
-            elif isinstance(val, str):
-                team_ids.add(val)
-
+        if val_id := _extract_id(data.get(field)):
+            team_ids.add(val_id)
     return team_ids
 
 
@@ -64,22 +83,6 @@ def _get_match_scores(data: dict[str, Any]) -> tuple[int, int]:
 
 def _resolve_team_document_ids(data: dict[str, Any]) -> tuple[str | None, str | None]:
     """Extract Team document IDs if available."""
-    t1_id = None
-    t1_ref = data.get("team1Ref")
-    if t1_ref and hasattr(t1_ref, "id"):
-        t1_id = t1_ref.id
-    elif isinstance(t1_ref, str):
-        t1_id = t1_ref
-    else:
-        t1_id = data.get("team1Id")
-
-    t2_id = None
-    t2_ref = data.get("team2Ref")
-    if t2_ref and hasattr(t2_ref, "id"):
-        t2_id = t2_ref.id
-    elif isinstance(t2_ref, str):
-        t2_id = t2_ref
-    else:
-        t2_id = data.get("team2Id")
-
+    t1_id = _extract_id(data.get("team1Ref")) or data.get("team1Id")
+    t2_id = _extract_id(data.get("team2Ref")) or data.get("team2Id")
     return t1_id, t2_id


### PR DESCRIPTION
This PR refactors several monolithic functions in the Group domain to improve maintainability and reduce cognitive load for developers (and AI agents).

### Changes:
- **`pickaladder/group/services/match_parser.py`**:
    - Introduced `_extract_id(val)` to unify ID retrieval from Refs, dicts, or strings.
    - Refactored `_resolve_team_ids` by extracting `_resolve_from_team_key` and `_resolve_from_individual_fields`.
    - Simplified `_resolve_team_document_ids` using the new `_extract_id` helper.
- **`pickaladder/group/routes.py`**:
    - Simplified `view_group` by extracting `_handle_referrer`, `_handle_invite_friend_form`, and `_handle_invite_email_form`.
    - Simplified `edit_group` by extracting `_get_group_for_edit` (fetching + permission check) and `_handle_edit_group_form`.

All modified functions are now well under 50 lines of code, and the logic is much easier to follow. No functional changes were made, and all relevant tests pass.

Fixes #1225

---
*PR created automatically by Jules for task [2848405950494686109](https://jules.google.com/task/2848405950494686109) started by @brewmarsh*