### PR TITLE
Refactor test infrastructure to reduce ACL

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -72,33 +72,33 @@ Query.where = query_where  # type: ignore[assignment]
 original_compare_func = Query._compare_func  # type: ignore[attr-defined]
 
 
+def _get_id_if_exists(obj: Any) -> Any:
+    """Return obj.id if it exists, otherwise obj."""
+    if hasattr(obj, "id"):
+        return obj.id
+    return obj
+
+
+def _in_op(x: Any, y: list[Any]) -> bool:
+    """Handle 'in' operator mock."""
+    normalized_y = [_get_id_if_exists(item) for item in y]
+    x_val = _get_id_if_exists(x)
+    return x_val in normalized_y
+
+
+def _array_contains_op(x: list[Any] | None, y: Any) -> bool:
+    """Handle 'array_contains' operator mock."""
+    if x is None:
+        return False
+    return y in x
+
+
 def query_compare_func(self: Query, op: str) -> Any:
     """Handle document ID comparisons and array_contains."""
     if op == "in":
-
-        def in_op(x: Any, y: list[Any]) -> bool:
-            """Handle 'in' operator mock."""
-            normalized_y = []
-            for item in y:
-                if hasattr(item, "id"):
-                    normalized_y.append(item.id)
-                else:
-                    normalized_y.append(item)
-            x_val = x
-            if hasattr(x, "id"):
-                x_val = x.id
-            return x_val in normalized_y
-
-        return in_op
+        return _in_op
     elif op == "array_contains":
-
-        def array_contains_op(x: list[Any] | None, y: Any) -> bool:
-            """Handle 'array_contains' operator mock."""
-            if x is None:
-                return False
-            return y in x
-
-        return array_contains_op
+        return _array_contains_op
     return original_compare_func(self, op)
 
 
@@ -173,6 +173,44 @@ def mock_array_remove(values: list[Any]) -> MockSentinel:
 original_update = DocumentReference.update
 
 
+def _apply_e2e_union(current_list: list[Any], values: list[Any]) -> list[Any]:
+    """Apply union operation for e2e tests."""
+    result = list(current_list)
+    for item in values:
+        if item not in result:
+            result.append(item)
+    return result
+
+
+def _apply_e2e_remove(current_list: list[Any], values: list[Any]) -> list[Any]:
+    """Apply remove operation for e2e tests."""
+    return [item for item in current_list if item not in values]
+
+
+def _apply_e2e_array_op(current_list: list[Any], sentinel: MockSentinel) -> list[Any]:
+    """Apply UNION or REMOVE operation to a list in e2e tests."""
+    if sentinel.op == "UNION":
+        return _apply_e2e_union(current_list, sentinel.values)
+    if sentinel.op == "REMOVE":
+        return _apply_e2e_remove(current_list, sentinel.values)
+    return current_list
+
+
+def _handle_e2e_sentinels(
+    doc_ref: DocumentReference, sentinels: dict[str, MockSentinel]
+) -> dict[str, Any]:
+    """Handle sentinel updates for e2e tests."""
+    doc_snapshot = doc_ref.get()
+    doc_data = doc_snapshot.to_dict() if doc_snapshot.exists else {}
+
+    for key, value in sentinels.items():
+        current_list = doc_data.get(key, [])
+        if not isinstance(current_list, list):
+            current_list = []
+        doc_data[key] = _apply_e2e_array_op(current_list, value)
+    return doc_data
+
+
 def doc_ref_update(self: DocumentReference, data: dict[str, Any]) -> None:
     """Update document handling sentinels and nested fields."""
     sentinels = {k: v for k, v in data.items() if isinstance(v, MockSentinel)}
@@ -185,26 +223,26 @@ def doc_ref_update(self: DocumentReference, data: dict[str, Any]) -> None:
         original_update(self, others)
 
     if sentinels:
-        doc_snapshot = self.get()
-        doc_data = doc_snapshot.to_dict() if doc_snapshot.exists else {}
-
-        for key, value in sentinels.items():
-            current_list = doc_data.get(key, [])
-            if not isinstance(current_list, list):
-                current_list = []
-            if value.op == "UNION":
-                for item in value.values:
-                    if item not in current_list:
-                        current_list.append(item)
-            elif value.op == "REMOVE":
-                for item in value.values:
-                    if item in current_list:
-                        current_list.remove(item)
-            doc_data[key] = current_list
-        self.set(doc_data)
+        new_doc_data = _handle_e2e_sentinels(self, sentinels)
+        self.set(new_doc_data)
 
 
 DocumentReference.update = doc_ref_update  # type: ignore[method-assign]
+
+
+def _execute_batch_op(op: tuple[Any, ...]) -> None:
+    """Execute a single batch operation."""
+    op_type = op[0]
+    if op_type == "set":
+        op[1].set(op[2], merge=op[3])
+        return
+    if op_type == "update":
+        op[1].update(op[2])
+        return
+    if op_type == "delete":
+        op[1].delete()
+        return
+
 
 # --- Mock Classes ---
 
@@ -244,12 +282,7 @@ class MockBatch:
     def commit(self) -> None:
         """Mock commit."""
         for op in self.ops:
-            if op[0] == "set":
-                op[1].set(op[2], merge=op[3])
-            elif op[0] == "update":
-                op[1].update(op[2])
-            elif op[0] == "delete":
-                op[1].delete()
+            _execute_batch_op(op)
         self.ops = []
 
 

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -55,83 +55,137 @@ class MockBatch:
                 ref.update(data)
 
 
+def _apply_array_union(current_list: list[Any], values: list[Any]) -> list[Any]:
+    """Apply union operation."""
+    merged = list(current_list)
+    for item in values:
+        if item not in merged:
+            merged.append(item)
+    return merged
+
+
+def _apply_array_operation(
+    current_list: list[Any], sentinel: MockArrayUnion | MockArrayRemove
+) -> list[Any]:
+    """Apply ArrayUnion or ArrayRemove operation to a list."""
+    if isinstance(sentinel, MockArrayUnion):
+        return _apply_array_union(current_list, sentinel.values)
+    # Must be MockArrayRemove
+    return [i for i in current_list if i not in sentinel.values]
+
+
+def _handle_sentinel_updates(
+    doc_ref: Any, sentinels: dict[str, MockArrayUnion | MockArrayRemove]
+) -> dict[str, list[Any]]:
+    """Process sentinel updates and return the new data dictionary."""
+    current_data = doc_ref.get().to_dict() or {}
+    new_data = {}
+    for k, v in sentinels.items():
+        existing = current_data.get(k, [])
+        if not isinstance(existing, list):
+            existing = []
+        new_data[k] = _apply_array_operation(existing, v)
+    return new_data
+
+
+def _patched_update(self: Any, data: dict[str, Any]) -> Any:
+    """Internal update method that handles sentinels."""
+    sentinels = {
+        k: v
+        for k, v in data.items()
+        if isinstance(v, (MockArrayUnion, MockArrayRemove))
+    }
+    others = {
+        k: v
+        for k, v in data.items()
+        if not isinstance(v, (MockArrayUnion, MockArrayRemove))
+    }
+
+    if others:
+        self._orig_update(others)
+
+    if sentinels:
+        new_data = _handle_sentinel_updates(self, sentinels)
+        # MockFirestore's DocumentReference.update updates its internal _data.
+        # Use the original update to ensure any other logic is preserved.
+        return self._orig_update(new_data)
+    return None
+
+
+def _where_impl(
+    self: Any,
+    field_path: Optional[str] = None,
+    op_string: Optional[str] = None,
+    value: Any = None,
+    filter: Any = None,
+) -> Any:
+    """Implementation of where that handles FieldFilter."""
+    if filter:
+        return self._where(filter.field_path, filter.op_string, filter.value)
+    return self._where(field_path, op_string, value)
+
+
+def _patched_compare_func(self: Any, op: str) -> Any:
+    """Patched comparison function for Query."""
+    if op == "array_contains":
+        return lambda x, y: x is not None and y in x
+    return self._orig_compare_func(op)
+
+
+def _doc_ref_eq(self: Any, other: Any) -> bool:
+    """Equality for DocumentReference."""
+    if not isinstance(other, DocumentReference):
+        return False
+    return self._path == other._path
+
+
+def _doc_ref_hash_fn(self: Any) -> int:
+    """Hash for DocumentReference."""
+    return hash(tuple(self._path))
+
+
+def _patched_doc_ref_get(self: Any, transaction: Any = None) -> Any:
+    """Handle transaction argument in get."""
+    return self._orig_get()
+
+
 class MockFirestoreBuilder:
     """Builder to modularize mockfirestore and firebase_admin patching."""
 
     @staticmethod
     def _patch_where_methods() -> None:
         """Patch CollectionReference and Query where methods to support FieldFilter."""
-
-        def collection_where(
-            self: Any,
-            field_path: Optional[str] = None,
-            op_string: Optional[str] = None,
-            value: Any = None,
-            filter: Any = None,
-        ) -> Any:
-            if filter:
-                return self._where(filter.field_path, filter.op_string, filter.value)
-            return self._where(field_path, op_string, value)
-
         if not hasattr(CollectionReference, "_where"):
             CollectionReference._where = CollectionReference.where
-            CollectionReference.where = collection_where
-
-        def query_where(
-            self: Any,
-            field_path: Optional[str] = None,
-            op_string: Optional[str] = None,
-            value: Any = None,
-            filter: Any = None,
-        ) -> Any:
-            if filter:
-                return self._where(filter.field_path, filter.op_string, filter.value)
-            return self._where(field_path, op_string, value)
+            CollectionReference.where = _where_impl
 
         if not hasattr(Query, "_where"):
             Query._where = Query.where
-            Query.where = query_where
+            Query.where = _where_impl
 
     @staticmethod
     def _patch_doc_ref_identity() -> None:
         """Patch DocumentReference equality and hashing."""
-
-        def doc_ref_eq(self: Any, other: Any) -> bool:
-            if not isinstance(other, DocumentReference):
-                return False
-            return self._path == other._path
-
         if not hasattr(DocumentReference, "_orig_eq"):
             DocumentReference._orig_eq = DocumentReference.__eq__
-            DocumentReference.__eq__ = doc_ref_eq
+            DocumentReference.__eq__ = _doc_ref_eq
 
         if not hasattr(DocumentReference, "__hash__"):
-            DocumentReference.__hash__ = lambda self: hash(tuple(self._path))
+            DocumentReference.__hash__ = _doc_ref_hash_fn
 
     @staticmethod
     def _patch_query_comparison() -> None:
         """Patch Query._compare_func to handle array_contains safely."""
         if not hasattr(Query, "_orig_compare_func"):
             Query._orig_compare_func = Query._compare_func
-
-            def patched_compare_func(self: Any, op: str) -> Any:
-                if op == "array_contains":
-                    return lambda x, y: x is not None and y in x
-                return self._orig_compare_func(op)
-
-            Query._compare_func = patched_compare_func
+            Query._compare_func = _patched_compare_func
 
     @staticmethod
     def _patch_doc_ref_get() -> None:
         """Patch DocumentReference.get to handle transaction argument."""
         if not hasattr(DocumentReference, "_orig_get"):
             DocumentReference._orig_get = DocumentReference.get
-
-            def doc_ref_get(self: Any, transaction: Any = None) -> Any:
-                """Handle transaction argument in get."""
-                return self._orig_get()
-
-            DocumentReference.get = doc_ref_get
+            DocumentReference.get = _patched_doc_ref_get
 
     @staticmethod
     def patch_db_read() -> None:
@@ -146,48 +200,7 @@ class MockFirestoreBuilder:
         """Apply monkeypatches to mockfirestore to support update with sentinels."""
         if not hasattr(DocumentReference, "_orig_update"):
             DocumentReference._orig_update = DocumentReference.update
-
-            def patched_update(self: Any, data: dict[str, Any]) -> Any:
-                sentinels = {
-                    k: v
-                    for k, v in data.items()
-                    if isinstance(v, (MockArrayUnion, MockArrayRemove))
-                }
-                others = {
-                    k: v
-                    for k, v in data.items()
-                    if not isinstance(v, (MockArrayUnion, MockArrayRemove))
-                }
-
-                if others:
-                    self._orig_update(others)
-
-                if sentinels:
-                    current_data = self.get().to_dict() or {}
-                    new_data = {}
-                    for k, v in sentinels.items():
-                        if isinstance(v, MockArrayUnion):
-                            existing = current_data.get(k, [])
-                            if not isinstance(existing, list):
-                                existing = []
-                            # Simple append for mock, firestore does set union
-                            merged = list(existing)
-                            for item in v.values:
-                                if item not in merged:
-                                    merged.append(item)
-                            new_data[k] = merged
-                        elif isinstance(v, MockArrayRemove):
-                            existing = current_data.get(k, [])
-                            if not isinstance(existing, list):
-                                existing = []
-                            new_data[k] = [i for i in existing if i not in v.values]
-
-                    # MockFirestore's DocumentReference.update updates its internal
-                    # _data.
-                    # Use the original update to ensure any other logic is preserved.
-                    return self._orig_update(new_data)
-
-            DocumentReference.update = patched_update
+            DocumentReference.update = _patched_update
 
     @staticmethod
     def patch_db_auth() -> unittest.mock.MagicMock:


### PR DESCRIPTION
Refactored high-complexity mock functions in `tests/mock_utils.py` and `tests/e2e/conftest.py` to achieve an ACL score under 10. Decomposed `patch_db_write`, `doc_ref_update`, `query_compare_func`, and `MockBatch.commit` into smaller private helper functions. Verified functional parity with the existing test suite and confirmed ACL reduction using the `agent-score` tool.

Fixes #1223

---
*PR created automatically by Jules for task [9530877451965277352](https://jules.google.com/task/9530877451965277352) started by @brewmarsh*