### PR TITLE
Refactor CSS utilities and standardize template styles

### DIFF
--- a/pickaladder/static/css/buttons.css
+++ b/pickaladder/static/css/buttons.css
@@ -105,3 +105,19 @@
 .btn-action i {
     font-size: 0.9em;
 }
+
+/* Button specific extensions */
+.btn-circle-sm {
+    width: 32px;
+    height: 32px;
+    border-radius: 50% !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 !important;
+}
+.btn-transparent {
+    background: transparent !important;
+    border: none !important;
+    width: auto !important;
+}

--- a/pickaladder/static/css/cards.css
+++ b/pickaladder/static/css/cards.css
@@ -279,3 +279,20 @@
 .tournament-card .card-badges {
     white-space: nowrap;
 }
+
+/* Card specific extensions */
+.card-accent-border { border-left: 5px solid var(--accent-color) !important; }
+.card-header-no-border { border-bottom: none !important; }
+
+/* Tournament Card specific styles */
+.tournament-card-header-img { width: 100%; height: 160px; object-fit: cover; }
+.tournament-card-placeholder {
+    width: 100%;
+    height: 160px;
+    background-color: var(--primary-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 3rem;
+}

--- a/pickaladder/static/css/data-displays.css
+++ b/pickaladder/static/css/data-displays.css
@@ -216,3 +216,13 @@
 .upset-mini-badge {
     font-size: 0.75rem;
 }
+
+.badge-circle-stat {
+    width: 28px;
+    height: 28px;
+    line-height: 20px;
+    border-radius: 50% !important;
+    padding: 4px 0 !important;
+    text-align: center;
+    display: inline-block;
+}

--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -1,8 +1,6 @@
 /* --- 0. Layout Utilities --- */
 .w-auto { width: auto !important; }
 .mx-auto { margin-left: auto !important; margin-right: auto !important; }
-.gap-4 { gap: 1.5rem !important; }
-.justify-content-center { justify-content: center !important; }
 .text-center { text-align: center !important; }
 .text-danger { color: var(--danger-color) !important; }
 .border-danger { border: 1px solid var(--danger-color) !important; }
@@ -167,3 +165,127 @@ body .d-none { display: none !important; }
         font-size: 2.5rem;
     }
 }
+
+/* Generic Flex/Layout Utilities */
+.flex-1 { flex: 1 !important; }
+.flex-2 { flex: 2 !important; }
+.flex-2-5 { flex: 2.5 !important; }
+.flex-grow-1 { flex-grow: 1 !important; }
+.flex-shrink-0 { flex-shrink: 0 !important; }
+.d-flex-column { display: flex !important; flex-direction: column !important; }
+.align-items-center { align-items: center !important; }
+.align-items-start { align-items: flex-start !important; }
+.align-items-stretch { align-items: stretch !important; }
+.justify-content-between { justify-content: space-between !important; }
+.justify-content-end { justify-content: flex-end !important; }
+.justify-content-center { justify-content: center !important; }
+
+/* Sizing Utilities */
+.min-w-0 { min-width: 0 !important; }
+.min-w-300 { min-width: 300px !important; }
+.w-100 { width: 100% !important; }
+.w-30 { width: 30px !important; }
+.w-20 { width: 20px !important; }
+.w-16 { width: 16px !important; }
+.h-100 { height: 100% !important; }
+.h-20 { height: 20px !important; }
+
+/* Spacing Utilities */
+.m-0 { margin: 0 !important; }
+.mt-0 { margin-top: 0 !important; }
+.mb-0 { margin-bottom: 0 !important; }
+.ml-0 { margin-left: 0 !important; }
+.mr-0 { margin-right: 0 !important; }
+
+.m-1 { margin: 4px !important; }
+.mt-1 { margin-top: 4px !important; }
+.mb-1 { margin-bottom: 4px !important; }
+.ml-1 { margin-left: 4px !important; }
+.mr-1 { margin-right: 4px !important; }
+
+.m-2 { margin: 8px !important; }
+.mt-2 { margin-top: 8px !important; }
+.mb-2 { margin-bottom: 8px !important; }
+.ml-2 { margin-left: 8px !important; }
+.mr-2 { margin-right: 8px !important; }
+
+.m-3 { margin: 16px !important; }
+.mt-3 { margin-top: 16px !important; }
+.mb-3 { margin-bottom: 16px !important; }
+.ml-3 { margin-left: 16px !important; }
+.mr-3 { margin-right: 16px !important; }
+
+.m-4 { margin: 24px !important; }
+.mt-4 { margin-top: 24px !important; }
+.mb-4 { margin-bottom: 24px !important; }
+.ml-4 { margin-left: 24px !important; }
+.mr-4 { margin-right: 24px !important; }
+
+.m-5 { margin: 48px !important; }
+.mt-5 { margin-top: 48px !important; }
+.mb-5 { margin-bottom: 48px !important; }
+
+.p-0 { padding: 0 !important; }
+.p-1 { padding: 4px !important; }
+.p-2 { padding: 8px !important; }
+.p-3 { padding: 16px !important; }
+.p-4 { padding: 24px !important; }
+.p-5 { padding: 48px !important; }
+
+.py-1 { padding-top: 4px !important; padding-bottom: 4px !important; }
+.py-2 { padding-top: 8px !important; padding-bottom: 8px !important; }
+.py-3 { padding-top: 16px !important; padding-bottom: 16px !important; }
+.px-1 { padding-left: 4px !important; padding-right: 4px !important; }
+.px-2 { padding-left: 8px !important; padding-right: 8px !important; }
+.px-3 { padding-left: 16px !important; padding-right: 16px !important; }
+
+.pl-0 { padding-left: 0 !important; }
+.pr-0 { padding-right: 0 !important; }
+
+.mb-40 { margin-bottom: 40px !important; }
+
+.gap-1 { gap: 4px !important; }
+.gap-2 { gap: 8px !important; }
+.gap-10 { gap: 10px !important; }
+.gap-3 { gap: 16px !important; }
+.gap-4 { gap: 24px !important; }
+.gap-5 { gap: 48px !important; }
+
+/* Typography Utilities */
+.text-right { text-align: right !important; }
+.text-uppercase { text-transform: uppercase !important; }
+.text-none { text-transform: none !important; }
+.ls-1 { letter-spacing: 1px !important; }
+.v-align-middle { vertical-align: middle !important; }
+.text-white { color: white !important; }
+.text-volt, .text-accent { color: var(--accent-color) !important; }
+.fw-semibold { font-weight: 600 !important; }
+.fw-bold { font-weight: 700 !important; }
+.lh-1-2 { line-height: 1.2 !important; }
+.color-inherit { color: inherit !important; }
+
+/* Font Size Utilities */
+.fs-xxs { font-size: 0.7rem !important; }
+.fs-xs { font-size: 0.75rem !important; }
+.fs-sm { font-size: 0.85rem !important; }
+.fs-md { font-size: 1rem !important; }
+.fs-lg { font-size: 1.1rem !important; }
+.fs-xl { font-size: 1.2rem !important; }
+.fs-2xl { font-size: 1.25rem !important; }
+.fs-giant { font-size: 3rem !important; }
+
+/* Border & Other Utilities */
+.border-none { border: none !important; }
+.bg-none { background: none !important; }
+.bg-primary { background-color: var(--primary-color) !important; }
+.bg-black-50 { background: rgba(0,0,0,0.5) !important; }
+.shadow-none { box-shadow: none !important; }
+.cursor-pointer { cursor: pointer !important; }
+.list-style-none { list-style: none !important; }
+.opacity-60 { opacity: 0.6 !important; }
+.opacity-80 { opacity: 0.8 !important; }
+.overflow-hidden { overflow: hidden !important; }
+.position-relative { position: relative !important; }
+.pos-abs-tr-10 { position: absolute !important; top: 10px !important; right: 10px !important; }
+.zi-10 { z-index: 10 !important; }
+.rounded-0 { border-radius: 0 !important; }

--- a/pickaladder/templates/components/_tournament_card.html
+++ b/pickaladder/templates/components/_tournament_card.html
@@ -1,14 +1,14 @@
 {% macro tournament_card(tournament) %}
-<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; height: 100%; display: flex; flex-direction: column;">
+<div class="card tournament-card clickable-row p-0 overflow-hidden position-relative h-100 d-flex flex-column" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}">
     {% if tournament.banner_url %}
-        <img src="{{ tournament.banner_url }}" alt="{{ tournament.name }}" style="width: 100%; height: 160px; object-fit: cover;">
+        <img src="{{ tournament.banner_url }}" alt="{{ tournament.name }}" class="tournament-card-header-img">
     {% else %}
-        <div style="width: 100%; height: 160px; background-color: var(--primary-color); display: flex; align-items: center; justify-content: center; color: white; font-size: 3rem;">🎾</div>
+        <div class="tournament-card-placeholder">🎾</div>
     {% endif %}
 
     {% if g.user and (g.user.uid == tournament.organizer_id or g.user.isAdmin) %}
-    <div class="dropdown kebab-menu" style="position: absolute; top: 10px; right: 10px; z-index: 10;" onclick="event.stopPropagation();">
-        <button class="dropbtn" type="button" style="background: rgba(0,0,0,0.5); color: white; width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; border: none; cursor: pointer;">
+    <div class="dropdown kebab-menu pos-abs-tr-10 zi-10" onclick="event.stopPropagation();">
+        <button class="dropbtn btn-circle-sm bg-black-50 text-white border-none cursor-pointer" type="button">
             <i class="fas fa-ellipsis-v"></i>
         </button>
         <div class="dropdown-content">
@@ -19,9 +19,9 @@
                 <i class="fas fa-tasks mr-2"></i> Manage
             </a>
             <div class="dropdown-divider"></div>
-            <form action="{{ url_for('tournament.delete_tournament', tournament_id=tournament.id) }}" method="POST" style="display: block;" onsubmit="return confirm('Are you sure you want to delete this tournament?');">
+            <form action="{{ url_for('tournament.delete_tournament', tournament_id=tournament.id) }}" method="POST" class="d-block" onsubmit="return confirm('Are you sure you want to delete this tournament?');">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" style="width: 100%; text-align: left; padding: 12px 16px; border: none; background: none; color: var(--danger-color); cursor: pointer; font-size: 14px; display: flex; align-items: center;">
+                <button type="submit" class="btn-transparent text-left p-3 border-none bg-none text-danger cursor-pointer fs-sm d-flex align-items-center w-100">
                     <i class="fas fa-trash-alt mr-2"></i> Delete
                 </button>
             </form>
@@ -29,10 +29,10 @@
     </div>
     {% endif %}
 
-    <div style="padding: 20px; flex-grow: 1; display: flex; flex-direction: column;">
+    <div class="p-3 flex-grow-1 d-flex flex-column">
         <div class="d-flex justify-content-between align-items-start mb-2">
-            <h3 style="margin: 0; font-size: 1.25rem; line-height: 1.2;">{{ tournament.name }}</h3>
-            <div class="card-badges d-flex align-items-center gap-2" style="flex-shrink: 0; margin-left: 10px;">
+            <h3 class="m-0 fs-2xl lh-1-2">{{ tournament.name }}</h3>
+            <div class="card-badges d-flex align-items-center gap-2 flex-shrink-0 ml-2">
                 <span class="badge-outline">
                     {% if tournament.matchType|lower == 'doubles' %}
                         <i class="fas fa-users small"></i>
@@ -45,12 +45,12 @@
             </div>
         </div>
 
-        <div style="margin-top: auto;">
-            <p class="text-muted small mb-1" style="display: flex; align-items: center; gap: 8px;">
-                <i class="fas fa-calendar-alt" style="width: 16px; text-align: center;"></i> {{ tournament.date_display or tournament.date }}
+        <div class="mt-auto">
+            <p class="text-muted small mb-1 d-flex align-items-center gap-2">
+                <i class="fas fa-calendar-alt w-16 text-center"></i> {{ tournament.date_display or tournament.date }}
             </p>
-            <p class="text-muted small mb-0" style="display: flex; align-items: center; gap: 8px;">
-                <i class="fas fa-map-marker-alt" style="width: 16px; text-align: center;"></i> {{ tournament.location_data.name if tournament.location_data else tournament.location }}
+            <p class="text-muted small mb-0 d-flex align-items-center gap-2">
+                <i class="fas fa-map-marker-alt w-16 text-center"></i> {{ tournament.location_data.name if tournament.location_data else tournament.location }}
             </p>
         </div>
     </div>

--- a/pickaladder/templates/dashboard.html
+++ b/pickaladder/templates/dashboard.html
@@ -34,7 +34,7 @@
                 <label for="profile_picture">Profile Picture:</label>
                 <input type="file" id="profile_picture" name="profile_picture" accept="image/png, image/jpeg, image/gif"
                     onchange="previewImage(event)">
-                <img id="preview" src="#" alt="your image" width="100" style="display:none;" />
+                <img id="preview" src="#" alt="your image" width="100" class="d-none" />
                 <label for="dupr_rating">DUPR Rating:</label>
                 <input type="number" step="0.01" id="dupr_rating" name="dupr_rating" value="{{ user.dupr_rating }}">
                 <button type="submit">Update Profile</button>
@@ -56,14 +56,14 @@
                             <td data-label="Username">{{ request[1] }}</td>
                             <td data-label="Actions">
                                 <form action="{{ url_for('user.accept_friend_request', friend_id=request[0]) }}"
-                                    method="post" style="display: inline;">
+                                    method="post" class="d-inline">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <button type="submit" class="button">Accept</button>
                                 </form>
                             </td>
                             <td>
                                 <form action="{{ url_for('user.decline_friend_request', friend_id=request[0]) }}"
-                                    method="post" style="display: inline;">
+                                    method="post" class="d-inline">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <button type="submit" class="button">Decline</button>
                                 </form>
@@ -147,6 +147,7 @@
                 reader.onload = function () {
                     var output = document.getElementById('preview');
                     output.src = reader.result;
+                    output.classList.remove('d-none');
                     output.style.display = 'block';
                 };
                 reader.readAsDataURL(event.target.files[0]);

--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -40,8 +40,7 @@
     {% if g.user and g.user.dark_mode %}data-theme="dark" {% endif %}
     {% if is_testing %}data-is-testing="true" {% endif %}>
     {% if config['FLASK_ENV'] == 'beta' %}
-    <div class="alert alert-primary text-center m-0"
-        style="background-color: var(--primary-color); color: white; border: none; border-radius: 0;">
+    <div class="alert alert-primary text-center m-0 bg-primary text-white border-none rounded-0">
         <strong>BETA MODE:</strong> Data is refreshed daily. Actions taken here will NOT be saved to Production.
     </div>
     {% endif %}
@@ -58,8 +57,7 @@
         {% for category, message in messages %}
         <div class="toast alert-{{ category }} show" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
-                <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2" alt="Logo"
-                    style="width: 20px; height: 20px;">
+                <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2 w-20 h-20" alt="Logo">
                 <strong>pickaladder</strong>
                 <button type="button" class="close" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
@@ -160,13 +158,13 @@
 
             let progressBar = '';
             if (category === 'info') {
-                progressBar = '<div class="progress"><div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div></div>';
+                progressBar = '<div class="progress"><div class="progress-bar progress-bar-striped progress-bar-animated w-100" role="progressbar"></div></div>';
             }
 
             const toastHTML = `
                 <div class="toast show alert-${category}" id="${toastId}" role="alert" aria-live="assertive" aria-atomic="true">
                     <div class="toast-header">
-                        <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2" alt="Logo" style="width: 20px; height: 20px;">
+                        <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2 w-20 h-20" alt="Logo">
                         <strong>pickaladder</strong>
                         <button type="button" class="close" aria-label="Close">
                             <span aria-hidden="true">&times;</span>

--- a/pickaladder/templates/user/profile.html
+++ b/pickaladder/templates/user/profile.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="mt-4">
     <div class="dashboard-columns">
-        <div class="dashboard-column-right" style="flex: 1; min-width: 300px;">
-            <div class="card text-center mb-4 border-0 shadow-sm">
+        <div class="dashboard-column-right flex-1 min-w-300">
+            <div class="card text-center mb-4 border-none shadow-sm">
                 <div class="card-body">
                     <img src="{{ profile_user | avatar_url }}" alt="Profile Picture" class="avatar avatar-xl mb-3"
                         onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
@@ -19,11 +19,10 @@
                                 {{ dupr if dupr is not none else 'Unrated' }}
                                 {% if profile_user.dupr_id %}
                                 <a href="{{ dupr_url_base }}{{ profile_user.dupr_id }}" target="_blank"
-                                    class="badge badge-primary ml-1"
-                                    style="font-size: 0.7rem; vertical-align: middle;">View on DUPR</a>
+                                    class="badge badge-primary ml-1 fs-xxs v-align-middle">View on DUPR</a>
                                 {% endif %}
                             </div>
-                            <small class="text-muted text-uppercase" style="font-size: 0.7rem; letter-spacing: 1px;">
+                            <small class="text-muted text-uppercase fs-xxs ls-1">
                                 DUPR Rating
                                 {% if not profile_user.dupr_id %}
                                 <br><a href="{{ url_for('user.edit_profile') }}" class="small">Add DUPR ID</a>
@@ -31,11 +30,10 @@
                             </small>
                         </div>
                         <div class="text-left">
-                            <span class="badge badge-volt d-block mb-1" style="font-size: 0.75rem;">Win Rate: {{
+                            <span class="badge badge-volt d-block mb-1 fs-xs">Win Rate: {{
                                 "%.0f"|format(win_rate) }}%</span>
                             <span
-                                class="badge {{ 'badge-volt' if streak_type == 'W' else 'badge-danger' if streak_type == 'L' else 'badge-info' }} d-block"
-                                style="font-size: 0.75rem;">Streak: {{ current_streak }}{{ streak_type if total_games >
+                                class="badge {{ 'badge-volt' if streak_type == 'W' else 'badge-danger' if streak_type == 'L' else 'badge-info' }} d-block fs-xs">Streak: {{ current_streak }}{{ streak_type if total_games >
                                 0 else '' }}</span>
                         </div>
                     </div>
@@ -57,7 +55,7 @@
 
                     {% if h2h_stats %}
                     <div class="mt-4 pt-3 border-top">
-                        <h6 class="text-muted text-uppercase mb-2" style="font-size: 0.75rem; letter-spacing: 1px;">Vs
+                        <h6 class="text-muted text-uppercase mb-2 fs-xs ls-1">Vs
                             You</h6>
                         <p class="h4 mb-0 font-weight-bold">
                             {{ h2h_stats.wins }}-{{ h2h_stats.losses }}
@@ -72,10 +70,10 @@
             </div>
         </div>
 
-        <div class="dashboard-column-left" style="flex: 2.5; min-width: 0;">
+        <div class="dashboard-column-left flex-2-5 min-w-0">
             <div class="dashboard-columns">
-                <div class="dashboard-column-left" style="flex: 2; min-width: 0;">
-                    <div class="card mb-4 border-0 shadow-sm">
+                <div class="dashboard-column-left flex-2 min-w-0">
+                    <div class="card mb-4 border-none shadow-sm">
                         <div class="card-header bg-white border-bottom-0 pt-4 pb-0">
                             <h4 class="font-weight-bold">Match History</h4>
                         </div>
@@ -88,8 +86,7 @@
                                     <div class="d-flex justify-content-between align-items-center">
                                         <div class="text-truncate mr-2">
                                             <span
-                                                class="badge {{ 'badge-volt' if match.user_result == 'win' else 'badge-danger' if match.user_result == 'loss' else 'badge-secondary' }} mr-2 text-center"
-                                                style="width: 28px; height: 28px; line-height: 20px; border-radius: 50%;">
+                                                class="badge {{ 'badge-volt' if match.user_result == 'win' else 'badge-danger' if match.user_result == 'loss' else 'badge-secondary' }} mr-2 text-center badge-circle-stat">
                                                 {{ 'W' if match.user_result == 'win' else 'L' if match.user_result ==
                                                 'loss' else 'D' }}
                                             </span>
@@ -132,8 +129,8 @@
                     </div>
                 </div>
 
-                <div class="dashboard-column-right" style="flex: 1; min-width: 0;">
-                    <div class="card mb-4 border-0 shadow-sm">
+                <div class="dashboard-column-right flex-1 min-w-0">
+                    <div class="card mb-4 border-none shadow-sm">
                         <div class="card-header bg-white border-bottom-0 pt-4 pb-2">
                             <h4 class="font-weight-bold">Friends</h4>
                         </div>
@@ -144,7 +141,7 @@
                                 <a href="{{ url_for('user.view_user', user_id=friend.id) }}"
                                     class="list-group-item list-group-item-action border-0 px-4 py-2 d-flex align-items-center">
                                     <img src="{{ friend | avatar_url }}" alt="" class="avatar avatar-md mr-3">
-                                    <div class="text-truncate font-weight-medium" style="font-size: 0.9rem;">{{ friend |
+                                    <div class="text-truncate font-weight-medium fs-sm">{{ friend |
                                         display_name }}</div>
                                 </a>
                                 {% endfor %}

--- a/pickaladder/templates/user/requests.html
+++ b/pickaladder/templates/user/requests.html
@@ -5,7 +5,7 @@
     <h1>Friend Requests</h1>
 </div>
 
-<div class="card requests-section" style="margin-bottom: 40px;">
+<div class="card requests-section mb-40">
     <h3>Pending Requests</h3>
     {% if requests %}
     <div class="table-container">
@@ -13,14 +13,14 @@
             <thead>
                 <tr>
                     <th>User</th>
-                    <th style="text-align: right;">Actions</th>
+                    <th class="text-right">Actions</th>
                 </tr>
             </thead>
             <tbody>
                 {% for request_user in requests %}
                 <tr>
                     <td data-label="User">
-                        <div style="display: flex; align-items: center; gap: 10px;">
+                        <div class="d-flex align-items-center gap-10">
                             <img src="{{ request_user | avatar_url }}" alt="{{ request_user | smart_display_name }}"
                                 class="avatar avatar-md"
                                 onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
@@ -28,14 +28,14 @@
                                     smart_display_name }}</strong></a>
                         </div>
                     </td>
-                    <td data-label="Actions" style="text-align: right;">
+                    <td data-label="Actions" class="text-right">
                         <form action="{{ url_for('user.accept_request', requester_id=request_user.id) }}" method="post"
-                            style="display: inline;">
+                            class="d-inline">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-primary">Confirm</button>
                         </form>
                         <form action="{{ url_for('user.cancel_request', target_id=request_user.id) }}" method="post"
-                            style="display: inline;">
+                            class="d-inline">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-outline-danger"
                                 onclick="return confirm('Are you sure you want to decline this friend request?');">Decline</button>
@@ -59,14 +59,14 @@
             <thead>
                 <tr>
                     <th>User</th>
-                    <th style="text-align: right;">Actions</th>
+                    <th class="text-right">Actions</th>
                 </tr>
             </thead>
             <tbody>
                 {% for request_user in sent_requests %}
                 <tr>
                     <td data-label="User">
-                        <div style="display: flex; align-items: center; gap: 10px;">
+                        <div class="d-flex align-items-center gap-10">
                             <img src="{{ request_user | avatar_url }}" alt="{{ request_user | smart_display_name }}"
                                 class="avatar avatar-md"
                                 onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
@@ -74,9 +74,9 @@
                                     smart_display_name }}</strong></a>
                         </div>
                     </td>
-                    <td data-label="Actions" style="text-align: right;">
+                    <td data-label="Actions" class="text-right">
                         <form action="{{ url_for('user.cancel_request', target_id=request_user.id) }}" method="post"
-                            style="display: inline;">
+                            class="d-inline">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-outline-danger"
                                 onclick="return confirm('Are you sure you want to cancel this friend request?');">Cancel</button>

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -10,23 +10,22 @@
     {# Section: Tournament Invites (Top Priority Alert Banner) #}
     {% if pending_tournament_invites %}
     {% for tournament in pending_tournament_invites %}
-    <div class="game-card tournament-invite-card"
-        style="margin-bottom: 20px; border-left: 5px solid var(--accent-color);">
-        <div style="flex: 2;">
-            <div style="font-weight: 600; font-size: 1.1rem; color: var(--accent-color);">🏆 You've been invited!</div>
-            <div style="font-size: 1.2rem; font-weight: bold; margin-top: 4px;">{{ tournament.name }}</div>
+    <div class="game-card tournament-invite-card mb-3 card-accent-border d-flex align-items-center p-3">
+        <div class="flex-2">
+            <div class="fw-semibold fs-lg text-volt">🏆 You've been invited!</div>
+            <div class="fs-xl fw-bold mt-1">{{ tournament.name }}</div>
             <div class="text-muted small">Starts {{ tournament.date }}</div>
         </div>
-        <div style="flex: 1; display: flex; justify-content: flex-end; gap: 10px; align-items: center;">
+        <div class="flex-1 d-flex justify-content-end align-items-center gap-2">
             <form action="{{ url_for('tournament.accept_invite', tournament_id=tournament.id) }}" method="post"
-                style="display: inline;">
+                class="d-inline">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="btn btn-volt" style="width: auto; margin: 0;">Accept</button>
+                <button type="submit" class="btn btn-volt w-auto m-0">Accept</button>
             </form>
             <form action="{{ url_for('tournament.decline_invite', tournament_id=tournament.id) }}" method="post"
-                style="display: inline;">
+                class="d-inline">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="btn btn-danger" style="width: auto; margin: 0;">Decline</button>
+                <button type="submit" class="btn btn-danger w-auto m-0">Decline</button>
             </form>
         </div>
     </div>
@@ -35,8 +34,8 @@
 
     {# Rookie Quest (Consolidated Onboarding) #}
     {% if onboarding_progress.percent < 100 or not onboarding_progress.has_match %}
-    <details class="card rookie-quest-card mb-4" style="border-left: 5px solid var(--accent-color);" open>
-        <summary class="card-header d-flex justify-content-between align-items-center" style="cursor: pointer; list-style: none;">
+    <details class="card rookie-quest-card mb-4 card-accent-border" open>
+        <summary class="card-header d-flex justify-content-between align-items-center cursor-pointer list-style-none">
             <h3 class="mb-0">Rookie Quest</h3>
             <i class="fas fa-chevron-down toggle-icon"></i>
         </summary>
@@ -56,8 +55,8 @@
                         {% set is_next = not quest.done and not ns.next_found %}
                         {% if is_next %}{% set ns.next_found = true %}{% endif %}
 
-                        <div class="list-group-item d-flex align-items-center {{ 'text-muted' if quest.done else '' }}" style="padding: 12px 0; border-color: var(--border-color); {{ 'opacity: 0.6;' if quest.done else '' }}">
-                            <div class="quest-icon" style="font-size: 1.2rem; width: 30px; text-align: center; margin-right: 12px;">
+                        <div class="list-group-item d-flex align-items-center py-3 {{ 'text-muted opacity-60' if quest.done else '' }}">
+                            <div class="quest-icon fs-xl w-30 text-center mr-3">
                                 {% if quest.done %}
                                     <i class="fas fa-check-circle text-success"></i>
                                 {% else %}
@@ -65,12 +64,12 @@
                                 {% endif %}
                             </div>
                             <div class="flex-grow-1 {{ 'strikethrough' if quest.done else '' }}">
-                                <div class="{{ 'fw-bold' if is_next else '' }}" style="font-size: 1rem;">{{ quest.title }}</div>
-                                <div class="text-muted small" style="font-size: 0.8rem;">{{ quest.text }}</div>
+                                <div class="fs-md {{ 'fw-bold' if is_next else '' }}">{{ quest.title }}</div>
+                                <div class="text-muted small fs-sm">{{ quest.text }}</div>
                             </div>
-                            <div style="margin-left: 12px;">
+                            <div class="ml-3">
                                 {% if not quest.done %}
-                                    <a href="{{ quest.link }}" class="btn {{ 'btn-volt pulse' if is_next else 'btn-outline-primary btn-sm' }}" style="width: auto; min-width: 60px; text-transform: none; margin: 0; padding: 4px 8px; font-size: 0.8rem;">
+                                    <a href="{{ quest.link }}" class="btn {{ 'btn-volt pulse' if is_next else 'btn-outline-primary btn-sm' }} w-auto text-none m-0 py-1 px-2 fs-sm">
                                         Go
                                     </a>
                                 {% endif %}
@@ -127,7 +126,7 @@
     {% if recent_opponents and onboarding_progress.percent == 100 %}
     <div class="card mb-4">
         <div class="card-body">
-            <h4 class="card-header" style="border-bottom: none; margin-bottom: 0; padding-left: 0;">Jump Back In</h4>
+            <h4 class="card-header card-header-no-border mb-0 pl-0">Jump Back In</h4>
             <div class="text-muted small mb-3">Recent Opponents</div>
             <div class="d-flex gap-3 mt-3">
                 {% for opponent in recent_opponents %}
@@ -206,7 +205,7 @@
                                             {% endif %}
                                             {{ user_score }} - {{ opp_score }}
                                             {% if match.tournament_name %}
-                                            <div class="text-muted small" style="margin-top: 4px;">🏆 {{ match.tournament_name }}</div>
+                                            <div class="text-muted small mt-1">🏆 {{ match.tournament_name }}</div>
                                             {% endif %}
                                         </div>
                                         {% if (match.created_by == user.uid and not match.tournament_id) or user.isAdmin %}
@@ -227,7 +226,7 @@
                     </div>
                     {% endif %}
                     {% else %}
-                    <p class="text-muted" style="padding: 20px; text-align: center;">No recent matches found.</p>
+                    <p class="text-muted p-4 text-center">No recent matches found.</p>
                     {% endif %}
                 </div>
             </div>
@@ -237,14 +236,14 @@
         <div class="dashboard-column-right">
             <div class="competition-stack">
                 {# Competitions Hub #}
-                <div class="card card-compact" style="padding: 16px;">
-                    <h3 style="margin-top: 0; margin-bottom: 16px;">Competitions</h3>
+                <div class="card card-compact">
+                    <h3 class="mt-0 mb-3">Competitions</h3>
                     {% if not active_tournaments and not group_rankings and not past_tournaments %}
                     <div class="text-center p-5">
-                        <div style="font-size: 3rem; margin-bottom: 1rem;">👨‍👩‍👧‍👦</div>
+                        <div class="fs-giant mb-3">👨‍👩‍👧‍👦</div>
                         <h4>Find your squad</h4>
-                        <p class="text-muted" style="margin-bottom: 24px;">Join a group or tournament to start competing and climb the ranks!</p>
-                        <a href="{{ url_for('user.view_community') }}" class="btn btn-volt" style="width: auto;">Find a Group</a>
+                        <p class="text-muted mb-4">Join a group or tournament to start competing and climb the ranks!</p>
+                        <a href="{{ url_for('user.view_community') }}" class="btn btn-volt w-auto">Find a Group</a>
                     </div>
                     {% else %}
                     <div class="d-flex flex-column gap-3">
@@ -257,16 +256,15 @@
                         <div class="list-group list-group-flush">
                         {% for ranking in group_rankings %}
                         <a href="{{ url_for('group.view_group', group_id=ranking.group_id) }}"
-                            class="list-group-item list-group-item-action"
-                            style="display: flex; align-items: center; padding: 12px 16px; text-decoration: none; color: inherit; border-bottom: 1px solid var(--border-color);">
+                            class="list-group-item list-group-item-action d-flex align-items-center py-2 px-3 border-bottom text-none color-inherit">
                             {% if ranking.group_image %}
-                            <div class="profile-picture-container avatar-sm" style="margin-right: 12px;">
+                            <div class="profile-picture-container avatar-sm mr-3">
                                 <img src="{{ ranking.group_image }}" alt="{{ ranking.group_name }}" class="profile-picture">
                             </div>
                             {% else %}
-                            <span style="margin-right: 12px; font-size: 1.25rem;">👥</span>
+                            <span class="mr-3 fs-2xl">👥</span>
                             {% endif %}
-                            <div style="flex-grow: 1;">
+                            <div class="flex-grow-1">
                                 <div class="fw-bold">{{ ranking.group_name }}</div>
                                 <div class="text-muted small">Rank #{{ ranking.rank or '?' }}</div>
                             </div>
@@ -276,7 +274,7 @@
 
                         {# Section 3: Past Tournaments (History) #}
                         {% for tournament in past_tournaments %}
-                            <div style="opacity: 0.8;">
+                            <div class="opacity-80">
                                 {{ tournament_card(tournament) }}
                             </div>
                         {% endfor %}
@@ -285,26 +283,24 @@
                 </div>
 
                 {# Social Section #}
-                <div class="card" style="padding: 16px;">
-                    <h3 style="margin-top: 0; margin-bottom: 16px;">Social</h3>
+                <div class="card card-compact">
+                    <h3 class="mt-0 mb-3">Social</h3>
                     {% if requests %}
-                    <h4 style="font-size: 0.9rem; margin-bottom: 8px;">Friend Requests</h4>
-                    <div class="table-container"
-                        style="box-shadow: none; border: 1px solid var(--border-color); margin-bottom: 16px; border-radius: 4px;">
-                        <table class="table" style="margin-top: 0;">
+                    <h4 class="fs-sm fw-bold mb-2">Friend Requests</h4>
+                    <div class="table-container shadow-none border mb-3 rounded-sm">
+                        <table class="table mt-0">
                             <tbody>
                                 {% for request in requests %}
                                 <tr>
-                                    <td style="padding: 8px;">
+                                    <td class="p-2">
                                         <a href="{{ url_for('user.view_user', user_id=request.id) }}"
-                                            style="font-size: 0.85rem;">{{ request.username }}</a>
+                                            class="fs-sm">{{ request.username }}</a>
                                     </td>
-                                    <td style="padding: 8px; text-align: right;">
+                                    <td class="p-2 text-right">
                                         <form action="{{ url_for('user.accept_request', requester_id=request.id) }}"
-                                            method="post" style="display: inline;">
+                                            method="post" class="d-inline">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                            <button type="submit" class="btn btn-volt btn-sm"
-                                                style="padding: 4px 8px; font-size: 0.75rem; width: auto; text-transform: none;">Accept</button>
+                                            <button type="submit" class="btn btn-volt btn-sm p-1 px-2 fs-xs w-auto text-none">Accept</button>
                                         </form>
                                     </td>
                                 </tr>
@@ -314,8 +310,8 @@
                     </div>
                     {% endif %}
 
-                    <h4 style="font-size: 0.9rem; margin-bottom: 8px;">Your Friends</h4>
-                    <div style="display: flex; flex-wrap: wrap; gap: 8px;">
+                    <h4 class="fs-sm fw-bold mb-2">Your Friends</h4>
+                    <div class="d-flex flex-wrap gap-2">
                         {% for friend in friends[:10] %}
                         <a href="{{ url_for('user.view_user', user_id=friend.id) }}" title="{{ friend.username }}">
                             <img src="{{ friend | avatar_url }}" alt="{{ friend.username }}" class="avatar avatar-md">
@@ -324,8 +320,7 @@
                         <p class="text-muted small">No friends yet.</p>
                         {% endfor %}
                     </div>
-                    <a href="{{ url_for('user.view_community') }}" class="btn btn-sm btn-outline-primary"
-                        style="width: 100%; margin-top: 12px; text-transform: none;">Community Hub</a>
+                    <a href="{{ url_for('user.view_community') }}" class="btn btn-sm btn-outline-primary w-100 mt-3 text-none">Community Hub</a>
                 </div>
             </div>
         </div>
@@ -418,7 +413,7 @@
 
             let tournamentHtml = '';
             if (match.tournament_name) {
-                tournamentHtml = `<div class="text-muted small" style="margin-top: 4px;">🏆 ${match.tournament_name}</div>`;
+                tournamentHtml = `<div class="text-muted small mt-1">🏆 ${match.tournament_name}</div>`;
             }
 
             let editLinkHtml = '';


### PR DESCRIPTION
This change refactors the frontend CSS architecture by moving inline `style` attributes into centralized utility and component files.

Key improvements:
1. **Utility Scale:** Introduced a standardized spacing and font-size scale in `layout-utils.css` to ensure UI consistency.
2. **Component Standardization:** Defined reusable classes for cards (accent borders, tournament headers) and buttons (circles, transparent variations).
3. **Template Cleanup:** Migrated high-traffic pages (Dashboard, Profile, Tournament List) to use the new classes, significantly improving template readability.
4. **DRY Principles:** Eliminated dozens of redundant inline styles across the most visited pages.

The changes were verified by running the tournament E2E test suite and relevant unit tests, all of which passed. Visual verification was performed on the layout and global components.

Fixes #1290

---
*PR created automatically by Jules for task [18059943073626861425](https://jules.google.com/task/18059943073626861425) started by @brewmarsh*