### PR TITLE
Fix User Dashboard Sidebar Layout Overlap

### DIFF
--- a/pickaladder/static/css/cards.css
+++ b/pickaladder/static/css/cards.css
@@ -272,6 +272,12 @@
     transform: scale(1.1);
 }
 
+.tournament-card {
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}
+
 .tournament-card.clickable-row {
     cursor: pointer;
 }

--- a/pickaladder/templates/components/_tournament_card.html
+++ b/pickaladder/templates/components/_tournament_card.html
@@ -1,5 +1,5 @@
 {% macro tournament_card(tournament) %}
-<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; height: 100%; display: flex; flex-direction: column;">
+<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; height: 100%; width: 100%; display: flex; flex-direction: column;">
     {% if tournament.banner_url %}
         <img src="{{ tournament.banner_url }}" alt="{{ tournament.name }}" style="width: 100%; height: 160px; object-fit: cover;">
     {% else %}

--- a/pickaladder/templates/user/profile.html
+++ b/pickaladder/templates/user/profile.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="mt-4">
     <div class="dashboard-columns">
-        <div class="dashboard-column-right" style="flex: 1; min-width: 300px;">
+        <div class="dashboard-column-right" style="flex: 1; min-width: 0; width: 100%; max-width: 100%; overflow: hidden;">
             <div class="card text-center mb-4 border-0 shadow-sm">
                 <div class="card-body">
                     <img src="{{ profile_user | avatar_url }}" alt="Profile Picture" class="avatar avatar-xl mb-3"

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -241,7 +241,7 @@
         </div>
 
         {# Right Column: Competition Stack #}
-        <div class="dashboard-column-right">
+        <div class="dashboard-column-right" style="min-width: 0; width: 100%; max-width: 100%; overflow: hidden;">
             <div class="competition-stack">
                 {# Competitions Hub #}
                 <div class="card card-compact" style="padding: 16px;">


### PR DESCRIPTION
This submission fixes a CSS layout issue on the User Dashboard and Profile pages where the Competitions sidebar (containing Tournament cards) would overlap the main content column.

Key changes:
1. **Sidebar Constraints**: Modified `pickaladder/templates/user/profile.html` and `pickaladder/templates/user_dashboard.html` to remove fixed minimum widths and apply `min-width: 0`, `max-width: 100%`, and `overflow: hidden`. This allows the flexbox container to correctly calculate the sidebar width and contain any oversized children.
2. **Tournament Card Consistency**: Updated the `tournament_card` macro and the corresponding CSS in `pickaladder/static/css/cards.css` to ensure the cards always take up 100% of their parent container's width and hide any overflow.

These changes prevent visual "blowout" where long tournament names or badge groups could force the card wider than its allocated sidebar space.

Fixes #1312

---
*PR created automatically by Jules for task [6467701468492991820](https://jules.google.com/task/6467701468492991820) started by @brewmarsh*