### PR TITLE
Fix sidebar tournament-card overflow

### DIFF
--- a/pickaladder/static/css/cards.css
+++ b/pickaladder/static/css/cards.css
@@ -102,7 +102,6 @@
     position: relative;
     max-width: 350px;
     width: fit-content;
-    min-width: 280px;
     padding: 16px 8px;
     display: flex;
     flex-direction: column;
@@ -275,6 +274,8 @@
 .tournament-card {
     height: 100%;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
     overflow: hidden;
 }
 

--- a/pickaladder/static/css/layout.css
+++ b/pickaladder/static/css/layout.css
@@ -144,7 +144,7 @@ body {
 
 .card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 20px;
     margin-top: 20px;
 }
@@ -152,7 +152,7 @@ body {
 /* Resolved: Included both Groups and Tournament grid styles */
 .groups-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 24px;
 }
 
@@ -183,7 +183,7 @@ body {
 
 .tournament-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 24px;
 }
 

--- a/pickaladder/templates/components/_tournament_card.html
+++ b/pickaladder/templates/components/_tournament_card.html
@@ -1,5 +1,5 @@
 {% macro tournament_card(tournament) %}
-<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; height: 100%; width: 100%; display: flex; flex-direction: column;">
+<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; height: 100%; width: 100%; max-width: 100%; min-width: 0; display: flex; flex-direction: column;">
     {% if tournament.banner_url %}
         <img src="{{ tournament.banner_url }}" alt="{{ tournament.name }}" style="width: 100%; height: 160px; object-fit: cover;">
     {% else %}


### PR DESCRIPTION
This change fixes a layout bug where the tournament-card component would overflow the right-hand sidebar on the user dashboard. By setting min-width: 0 and max-width: 100%, and adjusting the global grid constraints, the cards now correctly respect their parent container's boundaries.

Fixes #1320

---
*PR created automatically by Jules for task [13467139716487964383](https://jules.google.com/task/13467139716487964383) started by @brewmarsh*