### PR TITLE
Refactor Tournament Creation with Volt Styling and Templates

### DIFF
--- a/pickaladder/static/css/buttons.css
+++ b/pickaladder/static/css/buttons.css
@@ -105,3 +105,94 @@
 .btn-action i {
     font-size: 0.9em;
 }
+
+/* --- 7. Segmented Controls --- */
+.segmented-control {
+    display: flex;
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 4px;
+    gap: 4px;
+}
+
+.segmented-item {
+    flex: 1;
+    text-align: center;
+    padding: 10px;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: all 0.2s ease;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 0;
+}
+
+.segmented-item:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.visually-hidden:checked + .segmented-item {
+    background-color: var(--color-volt);
+    color: var(--color-dark);
+    box-shadow: var(--shadow-sm);
+}
+
+[data-theme="dark"] .segmented-control {
+    background-color: #000000;
+}
+
+[data-theme="dark"] .segmented-item:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .visually-hidden:checked + .segmented-item {
+    background-color: var(--color-volt);
+    color: var(--color-dark);
+}
+
+/* --- 8. File Upload Styling --- */
+.file-upload-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.file-upload-button {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 10px 16px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: all 0.2s ease;
+    margin-bottom: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-primary);
+    box-shadow: var(--shadow-sm);
+}
+
+.file-upload-button:hover {
+    border-color: var(--color-volt);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.file-upload-input {
+    display: none;
+}
+
+.file-name-text {
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 250px;
+    color: var(--text-primary);
+    font-weight: 500;
+}

--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -1,4 +1,16 @@
 /* --- 0. Layout Utilities --- */
+.grid-2-col-responsive {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+@media (max-width: 768px) {
+    .grid-2-col-responsive {
+        grid-template-columns: 1fr !important;
+    }
+}
+
 .w-auto { width: auto !important; }
 .mx-auto { margin-left: auto !important; margin-right: auto !important; }
 .gap-4 { gap: 1.5rem !important; }
@@ -225,91 +237,6 @@ body .d-none { display: none !important; }
     }
 }
 
-/* --- 7. Segmented Controls --- */
-.segmented-control {
-    display: flex;
-    background-color: var(--bg-primary);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    padding: 4px;
-    gap: 4px;
-}
-
-.segmented-item {
-    flex: 1;
-    text-align: center;
-    padding: 10px;
-    cursor: pointer;
-    border-radius: var(--radius-sm);
-    transition: all 0.2s ease;
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--text-secondary);
-    margin-bottom: 0;
-}
-
-.segmented-item:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-}
-
-.visually-hidden:checked + .segmented-item {
-    background-color: var(--bg-secondary);
-    color: var(--primary-color);
-    box-shadow: var(--shadow-sm);
-}
-
-[data-theme="dark"] .segmented-control {
-    background-color: #000000;
-}
-
-[data-theme="dark"] .segmented-item:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
-[data-theme="dark"] .visually-hidden:checked + .segmented-item {
-    background-color: var(--card-bg);
-    color: var(--primary-color);
-}
-
-/* --- 8. File Upload Styling --- */
-.file-upload-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-top: 8px;
-}
-
-.file-upload-button {
-    background-color: var(--bg-primary);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    padding: 10px 16px;
-    cursor: pointer;
-    font-size: 14px;
-    font-weight: 500;
-    transition: all 0.2s ease;
-    margin-bottom: 0;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.file-upload-button:hover {
-    border-color: var(--primary-color);
-    color: var(--primary-color);
-}
-
-.file-upload-input {
-    display: none;
-}
-
-.file-name-text {
-    font-size: 14px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 250px;
-}
 
 /* --- Accessibility --- */
 .visually-hidden {

--- a/pickaladder/static/css/variables.css
+++ b/pickaladder/static/css/variables.css
@@ -5,6 +5,7 @@
     --accent-color: #84CC16;        /* Electric Lime */
     --accent-hover: #65A30D;
     --color-volt: var(--accent-color);
+    --color-dark: var(--text-on-accent);
 
     --success-color: #10B981;
     --danger-color: #EF4444;

--- a/pickaladder/templates/create_tournament.html
+++ b/pickaladder/templates/create_tournament.html
@@ -3,60 +3,183 @@
 {% block title %}Create Tournament{% endblock %}
 
 {% block content %}
-<div class="card" style="max-width: 600px; margin: 0 auto;">
+<div class="card" style="max-width: 800px; margin: 0 auto;">
     <div class="card-header">
         <h2>Create Tournament</h2>
     </div>
     <div class="card-body">
-        <form method="POST">
+        <!-- Template Selector -->
+        <div class="form-group mb-4">
+            <label for="template-selector" class="form-label fw-bold">Select Template (Pre-fill)</label>
+            <select id="template-selector" class="form-input" onchange="applyTemplate(this.value)">
+                <option value="">-- Choose a template --</option>
+                <option value="round_robin">Standard Round Robin</option>
+                <option value="single_elim">Single Elim Smash</option>
+                <option value="family_ladder">Family Ladder</option>
+            </select>
+            <small class="text-muted" id="template-description">Select a template to auto-populate common rules and formats.</small>
+        </div>
+
+        <hr class="mb-4">
+
+        <form method="POST" enctype="multipart/form-data">
             {{ form.csrf_token }}
+
             <div class="form-group">
                 {{ form.name.label(class="form-label") }}
-                {{ form.name(class="form-input") }}
+                {{ form.name(class="form-input", placeholder="Summer Smash 2024") }}
                 {% if form.name.errors %}
                     {% for error in form.name.errors %}
                         <span class="text-danger">{{ error }}</span>
                     {% endfor %}
                 {% endif %}
             </div>
+
             <div class="form-group">
-                {{ form.date.label(class="form-label") }}
-                {{ form.date(class="form-input", type="date") }}
-                {% if form.date.errors %}
-                    {% for error in form.date.errors %}
-                        <span class="text-danger">{{ error }}</span>
-                    {% endfor %}
-                {% endif %}
-            </div>
-            <div class="form-group">
-                {{ form.location.label(class="form-label") }}
-                {{ form.location(class="form-input") }}
-                {% if form.location.errors %}
-                    {% for error in form.location.errors %}
-                        <span class="text-danger">{{ error }}</span>
-                    {% endfor %}
-                {% endif %}
-            </div>
-            <div class="form-group">
-                {{ form.mode.label(class="form-label") }}
-                <div class="radio-group" style="display: flex; gap: 20px; padding: 10px 0;">
-                    {% for subfield in form.mode %}
-                        <label class="radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                            {{ subfield }}
-                            <span>{{ subfield.label.text }}</span>
-                        </label>
-                    {% endfor %}
+                {{ form.banner.label(class="form-label") }}
+                <div class="file-upload-wrapper">
+                    <label class="file-upload-button">
+                        <i class="fas fa-cloud-upload-alt"></i> Choose Image...
+                        {{ form.banner(class="file-upload-input", onchange="updateFileName(this)") }}
+                    </label>
+                    <span id="file-name-display" class="file-name-text">No file chosen</span>
                 </div>
-                {% if form.mode.errors %}
-                    {% for error in form.mode.errors %}
+                <small class="text-muted">Recommended: 16:9 aspect ratio.</small>
+                {% if form.banner.errors %}
+                    {% for error in form.banner.errors %}
                         <span class="text-danger">{{ error }}</span>
                     {% endfor %}
                 {% endif %}
             </div>
-            <div class="form-actions">
-                <button type="submit" class="btn btn-primary btn-block">Create Tournament</button>
+
+            <div class="grid-2-col-responsive">
+                <div class="form-group">
+                    {{ form.start_date.label(class="form-label") }}
+                    {{ form.start_date(class="form-input", type="date") }}
+                    {% if form.start_date.errors %}
+                        {% for error in form.start_date.errors %}
+                            <span class="text-danger">{{ error }}</span>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.venue_name.label(class="form-label") }}
+                    {{ form.venue_name(class="form-input", placeholder="Central Park Courts") }}
+                    {% if form.venue_name.errors %}
+                        {% for error in form.venue_name.errors %}
+                            <span class="text-danger">{{ error }}</span>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="form-group">
+                {{ form.address.label(class="form-label") }}
+                {{ form.address(class="form-input", placeholder="123 Park Lane, New York, NY") }}
+                <small class="text-muted">This will generate a 'Get Directions' link for players.</small>
+                {% if form.address.errors %}
+                    {% for error in form.address.errors %}
+                        <span class="text-danger">{{ error }}</span>
+                    {% endfor %}
+                {% endif %}
+            </div>
+
+            <div class="grid-2-col-responsive">
+                <div class="form-group">
+                    {{ form.match_type.label(class="form-label") }}
+                    <div class="segmented-control">
+                        {% for subfield in form.match_type %}
+                            {{ subfield(class="visually-hidden") }}
+                            <label for="{{ subfield.id }}" class="segmented-item">
+                                {% if subfield.data == 'SINGLES' %}
+                                    <i class="fas fa-user small"></i>
+                                {% else %}
+                                    <i class="fas fa-users small"></i>
+                                {% endif %}
+                                {{ subfield.label.text }}
+                            </label>
+                        {% endfor %}
+                    </div>
+                    {% if form.match_type.errors %}
+                        {% for error in form.match_type.errors %}
+                            <span class="text-danger">{{ error }}</span>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.format.label(class="form-label") }}
+                    {{ form.format(class="form-input") }}
+                    {% if form.format.errors %}
+                        {% for error in form.format.errors %}
+                            <span class="text-danger">{{ error }}</span>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="form-group">
+                {{ form.description.label(class="form-label") }}
+                {{ form.description(class="form-input", rows="5", placeholder="Rules, schedule, and other details...") }}
+                {% if form.description.errors %}
+                    {% for error in form.description.errors %}
+                        <span class="text-danger">{{ error }}</span>
+                    {% endfor %}
+                {% endif %}
+            </div>
+
+            <div class="form-actions mt-4 grid-2-col-responsive">
+                <button type="submit" class="btn btn-volt">Create Tournament</button>
+                <a href="{{ url_for('tournament.list_tournaments') }}" class="btn btn-secondary" style="line-height: 2.5;">Cancel</a>
             </div>
         </form>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const tournamentTemplates = {
+    "round_robin": {
+        "description": "Everyone plays everyone. Best for competitive league play.",
+        "match_type": "SINGLES",
+        "format": "ROUND_ROBIN"
+    },
+    "single_elim": {
+        "description": "Win or go home. Standard bracket tournament.",
+        "match_type": "SINGLES",
+        "format": "SINGLE_ELIMINATION"
+    },
+    "family_ladder": {
+        "description": "Casual doubles play for families. Round Robin format.",
+        "match_type": "DOUBLES",
+        "format": "ROUND_ROBIN"
+    }
+};
+
+function applyTemplate(templateKey) {
+    const template = tournamentTemplates[templateKey];
+    if (!template) {
+        document.getElementById('template-description').textContent = "Select a template to auto-populate common rules and formats.";
+        return;
+    }
+
+    document.getElementById('template-description').textContent = template.description;
+
+    // Set match_type (segmented control)
+    const matchTypeInputs = document.getElementsByName('match_type');
+    matchTypeInputs.forEach(input => {
+        if (input.value === template.match_type) {
+            input.checked = true;
+        }
+    });
+
+    // Set format (select)
+    document.getElementById('format').value = template.format;
+}
+
+function updateFileName(input) {
+    const fileName = input.files[0] ? input.files[0].name : 'No file chosen';
+    document.getElementById('file-name-display').textContent = fileName;
+}
+</script>
 {% endblock %}

--- a/pickaladder/templates/tournaments/create_edit.html
+++ b/pickaladder/templates/tournaments/create_edit.html
@@ -8,6 +8,21 @@
         <h2>{{ action }} Tournament</h2>
     </div>
     <div class="card-body">
+        {% if action == 'Create' %}
+        <!-- Template Selector -->
+        <div class="form-group mb-4">
+            <label for="template-selector" class="form-label fw-bold">Select Template (Pre-fill)</label>
+            <select id="template-selector" class="form-input" onchange="applyTemplate(this.value)">
+                <option value="">-- Choose a template --</option>
+                <option value="round_robin">Standard Round Robin</option>
+                <option value="single_elim">Single Elim Smash</option>
+                <option value="family_ladder">Family Ladder</option>
+            </select>
+            <small class="text-muted" id="template-description">Select a template to auto-populate common rules and formats.</small>
+        </div>
+        <hr class="mb-4">
+        {% endif %}
+
         <form method="POST" enctype="multipart/form-data">
             {{ form.csrf_token }}
 
@@ -33,7 +48,9 @@
                         <i class="fas fa-cloud-upload-alt"></i> Choose Image...
                         {{ form.banner(class="file-upload-input", onchange="updateFileName(this)") }}
                     </label>
-                    <span id="file-name-display" class="file-name-text text-muted">No file chosen</span>
+                    <span id="file-name-display" class="file-name-text">
+                        {% if tournament and tournament.banner_url %}Change current banner...{% else %}No file chosen{% endif %}
+                    </span>
                 </div>
                 <small class="text-muted">Recommended: 16:9 aspect ratio.</small>
                 {% if form.banner.errors %}
@@ -43,7 +60,7 @@
                 {% endif %}
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+            <div class="grid-2-col-responsive">
                 <div class="form-group">
                     {{ form.start_date.label(class="form-label") }}
                     {{ form.start_date(class="form-input", type="date") }}
@@ -75,7 +92,7 @@
                 {% endif %}
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+            <div class="grid-2-col-responsive">
                 <div class="form-group">
                     {{ form.match_type.label(class="form-label") }}
                     <div class="segmented-control">
@@ -118,29 +135,60 @@
                 {% endif %}
             </div>
 
-            <div class="form-actions" style="display: flex; gap: 10px; margin-top: 20px;">
-                <button type="submit" class="btn btn-primary" style="flex: 1;">{{ action }} Tournament</button>
+            <div class="form-actions mt-4 grid-2-col-responsive">
+                <button type="submit" class="btn btn-volt">{{ action }} Tournament</button>
                 {% if action == 'Edit' %}
-                    <a href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" class="btn btn-secondary" style="flex: 1; text-align: center; line-height: 2.5;">Cancel</a>
+                    <a href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" class="btn btn-secondary" style="line-height: 2.5;">Cancel</a>
                 {% else %}
-                    <a href="{{ url_for('tournament.list_tournaments') }}" class="btn btn-secondary" style="flex: 1; text-align: center; line-height: 2.5;">Cancel</a>
+                    <a href="{{ url_for('tournament.list_tournaments') }}" class="btn btn-secondary" style="line-height: 2.5;">Cancel</a>
                 {% endif %}
             </div>
         </form>
     </div>
 </div>
-
-<style>
-@media screen and (max-width: 600px) {
-    div[style*="grid-template-columns: 1fr 1fr"] {
-        grid-template-columns: 1fr !important;
-    }
-}
-</style>
 {% endblock %}
 
 {% block scripts %}
 <script>
+const tournamentTemplates = {
+    "round_robin": {
+        "description": "Everyone plays everyone. Best for competitive league play.",
+        "match_type": "SINGLES",
+        "format": "ROUND_ROBIN"
+    },
+    "single_elim": {
+        "description": "Win or go home. Standard bracket tournament.",
+        "match_type": "SINGLES",
+        "format": "SINGLE_ELIMINATION"
+    },
+    "family_ladder": {
+        "description": "Casual doubles play for families. Round Robin format.",
+        "match_type": "DOUBLES",
+        "format": "ROUND_ROBIN"
+    }
+};
+
+function applyTemplate(templateKey) {
+    const template = tournamentTemplates[templateKey];
+    if (!template) {
+        document.getElementById('template-description').textContent = "Select a template to auto-populate common rules and formats.";
+        return;
+    }
+
+    document.getElementById('template-description').textContent = template.description;
+
+    // Set match_type (segmented control)
+    const matchTypeInputs = document.getElementsByName('match_type');
+    matchTypeInputs.forEach(input => {
+        if (input.value === template.match_type) {
+            input.checked = true;
+        }
+    });
+
+    // Set format (select)
+    document.getElementById('format').value = template.format;
+}
+
 function updateFileName(input) {
     const fileName = input.files[0] ? input.files[0].name : 'No file chosen';
     document.getElementById('file-name-display').textContent = fileName;


### PR DESCRIPTION
This refactor updates the tournament creation experience with 'Volt' branding and a new Template Pre-fill system. 

Key changes include:
1. **Template Logic**: Added a 'Select Template' dropdown that auto-populates 'Competition Mode' and 'Tournament Format' for "Standard Round Robin", "Single Elim Smash", and "Family Ladder" options.
2. **Volt Styling**: 
    - Updated segmented controls to use the Electric Lime (`--color-volt`) accent for selected states.
    - Enhanced the file upload button with a premium 'cloud' icon and high-contrast text.
    - Standardized primary buttons to `.btn-volt`.
3. **Layout Standardization**: Replaced various inline styles with a new reusable `.grid-2-col-responsive` class that handles mobile stacking automatically.
4. **Code Quality**: Consolidated component-specific styles into `buttons.css` and unified the `create_tournament.html` and `create_edit.html` templates for a consistent experience across creation and editing.

Verified with E2E tests and manual visual inspection using Playwright screenshots.

Fixes #1337

---
*PR created automatically by Jules for task [1649018932699815958](https://jules.google.com/task/1649018932699815958) started by @brewmarsh*