### PR TITLE
Fix Certbot Implementation for .io Domain

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -96,7 +96,7 @@ docker rm -f picka-server_nginx_1 picka-server_web_1 picka-server_certbot_1 \
 # This script is designed to be run by the CI/CD pipeline on the production server.
 # It handles the initial Let's Encrypt certificate generation automatically.
 
-DOMAIN="app.pickaladder.com"
+DOMAIN="app.pickaladder.io"
 EMAIL="pickaladder@gmail.com"
 DATA_PATH="./certbot"
 CERT_DIR="$DATA_PATH/conf/live/$DOMAIN"

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -12,7 +12,7 @@ http {
     server {
         listen 80;
         listen [::]:80;
-        server_name app.pickaladder.com www.pickaladder.com;
+        server_name app.pickaladder.io www.app.pickaladder.io;
 
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
@@ -26,10 +26,10 @@ http {
     server {
         listen 443 ssl;
         listen [::]:443 ssl;
-        server_name app.pickaladder.com www.pickaladder.com;
+        server_name app.pickaladder.io www.app.pickaladder.io;
 
-        ssl_certificate /etc/letsencrypt/live/app.pickaladder.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/app.pickaladder.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/app.pickaladder.io/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/app.pickaladder.io/privkey.pem;
 
         location / {
             set $upstream_app web;

--- a/nginx/pickaladder
+++ b/nginx/pickaladder
@@ -1,15 +1,15 @@
 server {
     listen 80;
-    server_name pickaladder.com www.pickaladder.com;
+    server_name pickaladder.io www.pickaladder.io;
 
     location / {
-        return 301 https://app.pickaladder.com$request_uri;
+        return 301 https://app.pickaladder.io$request_uri;
     }
 }
 
 server {
     listen 80;
-    server_name app.pickaladder.com;
+    server_name app.pickaladder.io;
 
     location / {
         proxy_pass http://127.0.0.1:8000;

--- a/scripts/setup_nginx.sh
+++ b/scripts/setup_nginx.sh
@@ -11,4 +11,4 @@ sudo nginx -t
 sudo systemctl reload nginx
 
 # 4. Run Certbot to obtain SSL certificates
-sudo certbot --nginx -d app.pickaladder.com -d pickaladder.com -d www.pickaladder.com
+sudo certbot --nginx -d app.pickaladder.io -d www.app.pickaladder.io


### PR DESCRIPTION
This PR updates all Nginx and Certbot-related configurations to use the correct production domain `app.pickaladder.io` and its `www` subdomain. This resolves the NXDOMAIN issues previously encountered during SSL certificate issuance. The configuration includes the necessary `.well-known/acme-challenge/` block to support webroot verification.

Fixes #1379

---
*PR created automatically by Jules for task [1968178921187959339](https://jules.google.com/task/1968178921187959339) started by @brewmarsh*