### PR TITLE
Resolve SSL issues and expand domain coverage

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -206,7 +206,7 @@ else
         --agree-tos \
         --no-eff-email \
         --force-renewal \
-        -d $DOMAIN -d www.$DOMAIN
+        -d $DOMAIN -d www.$DOMAIN -d pickaladder.io -d www.pickaladder.io
 
     # 4. Stop the Nginx container that was using the dummy cert.
     # The next step will bring everything up with the real cert.

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -12,7 +12,7 @@ http {
     server {
         listen 80;
         listen [::]:80;
-        server_name app.pickaladder.io www.app.pickaladder.io;
+        server_name app.pickaladder.io www.app.pickaladder.io pickaladder.io www.pickaladder.io;
 
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
@@ -26,7 +26,7 @@ http {
     server {
         listen 443 ssl;
         listen [::]:443 ssl;
-        server_name app.pickaladder.io www.app.pickaladder.io;
+        server_name app.pickaladder.io www.app.pickaladder.io pickaladder.io www.pickaladder.io;
 
         ssl_certificate /etc/letsencrypt/live/app.pickaladder.io/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/app.pickaladder.io/privkey.pem;

--- a/nginx/pickaladder
+++ b/nginx/pickaladder
@@ -1,15 +1,6 @@
 server {
     listen 80;
-    server_name pickaladder.io www.pickaladder.io;
-
-    location / {
-        return 301 https://app.pickaladder.io$request_uri;
-    }
-}
-
-server {
-    listen 80;
-    server_name app.pickaladder.io;
+    server_name app.pickaladder.io www.app.pickaladder.io pickaladder.io www.pickaladder.io;
 
     location / {
         proxy_pass http://127.0.0.1:8000;

--- a/scripts/setup_nginx.sh
+++ b/scripts/setup_nginx.sh
@@ -11,4 +11,4 @@ sudo nginx -t
 sudo systemctl reload nginx
 
 # 4. Run Certbot to obtain SSL certificates
-sudo certbot --nginx -d app.pickaladder.io -d www.app.pickaladder.io
+sudo certbot --nginx -d app.pickaladder.io -d www.app.pickaladder.io -d pickaladder.io -d www.pickaladder.io


### PR DESCRIPTION
This change expands the SSL certificate and Nginx configuration to support all four domain variants: app.pickaladder.io, www.app.pickaladder.io, pickaladder.io, and www.pickaladder.io. This resolves the 'Common Name Invalid' error for users accessing the root or www domains. It also prepares the environment for resolving the Firebase 'Referer blocked' error by ensuring all domains are correctly served.

Fixes #1382

---
*PR created automatically by Jules for task [5009100326670120659](https://jules.google.com/task/5009100326670120659) started by @brewmarsh*