### PR TITLE
Fix Dashboard Layout and Badge Shape

### DIFF
--- a/pickaladder/static/css/data-displays.css
+++ b/pickaladder/static/css/data-displays.css
@@ -354,3 +354,13 @@
 .upset-mini-badge {
     font-size: 0.75rem;
 }
+
+/* Base Shapes */
+.match-score-badge-compact .badge.rounded-circle {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/pickaladder/static/css/layout.css
+++ b/pickaladder/static/css/layout.css
@@ -135,13 +135,18 @@ body {
 .hamburger-menu.active span:nth-child(3) { transform: rotate(-45deg) translate(5px, -5px); }
 
 .dashboard-columns {
-    display: grid;
-    grid-template-columns: 1fr 350px;
+    display: flex;
+    flex-wrap: wrap;
     gap: 24px;
 }
 
-.dashboard-column-left,
+.dashboard-column-left {
+    flex: 1;
+    min-width: 0;
+}
+
 .dashboard-column-right {
+    flex: 0 0 350px;
     min-width: 0;
 }
 
@@ -190,12 +195,10 @@ body {
     gap: 24px;
 }
 
-.tournament-card {
-    height: 100%;
-}
 
 @media screen and (max-width: 768px) {
-    .dashboard-columns { grid-template-columns: 1fr; }
+    .dashboard-columns { flex-direction: column; }
+    .dashboard-column-right { flex: 1 1 auto; }
     .navbar-menu { display: none; }
 }
 

--- a/pickaladder/templates/components/_tournament_card.html
+++ b/pickaladder/templates/components/_tournament_card.html
@@ -1,5 +1,5 @@
 {% macro tournament_card(tournament) %}
-<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; height: 100%; width: 100%; display: flex; flex-direction: column;">
+<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; width: 100%; display: flex; flex-direction: column;">
     {% if tournament.banner_url %}
         <img src="{{ tournament.banner_url }}" alt="{{ tournament.name }}" style="width: 100%; height: 160px; object-fit: cover;">
     {% else %}


### PR DESCRIPTION
This change addresses the dashboard layout issues where tournament cards overlapped other elements. By switching to Flexbox and properly managing wrapping and sidebar flex properties, the layout is now stable and responsive. The win/loss badges in match history are now perfectly circular, and global utility classes were preserved to avoid regressions. Tournament cards no longer stretch unnaturally.

Fixes #1384

---
*PR created automatically by Jules for task [5298727489450285781](https://jules.google.com/task/5298727489450285781) started by @brewmarsh*