### PR TITLE
Fix User Dashboard Layouts and Enforce CSS Grid

### DIFF
--- a/pickaladder/static/css/data-displays.css
+++ b/pickaladder/static/css/data-displays.css
@@ -37,8 +37,8 @@
     align-items: center;
     justify-content: center;
     padding: 0 !important;
-    flex-shrink: 0;
-    aspect-ratio: 1 / 1;
+    flex-shrink: 0 !important;
+    aspect-ratio: 1 / 1 !important;
     text-align: center;
     overflow: hidden;
 }

--- a/pickaladder/static/css/layout.css
+++ b/pickaladder/static/css/layout.css
@@ -78,10 +78,10 @@ body {
 /* --- Dashboard Column System (Refactored to Grid) --- */
 
 .dashboard-columns {
-    display: grid;
+    display: grid !important;
     /* Forces columns into specific tracks: Feed gets the rest, Sidebar gets exactly 350px */
-    grid-template-columns: 1fr var(--sidebar-width);
-    gap: 24px;
+    grid-template-columns: 1fr 350px !important;
+    gap: 24px !important;
     align-items: flex-start;
 }
 
@@ -90,6 +90,7 @@ body {
     /* Critical: prevents children (like wide cards) from shoving the column wider than its track */
     min-width: 0; 
     width: 100%;
+    overflow: hidden;
 }
 
 /* --- Grid Systems --- */

--- a/pickaladder/templates/components/_tournament_card.html
+++ b/pickaladder/templates/components/_tournament_card.html
@@ -1,5 +1,5 @@
 {% macro tournament_card(tournament) %}
-<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; width: 100%; display: flex; flex-direction: column;">
+<div class="card tournament-card clickable-row" data-href="{{ url_for('tournament.view_tournament', tournament_id=tournament.id) }}" style="padding: 0; overflow: hidden; position: relative; display: flex; flex-direction: column;">
     {% if tournament.banner_url %}
         <img src="{{ tournament.banner_url }}" alt="{{ tournament.name }}" style="width: 100%; height: 160px; object-fit: cover;">
     {% else %}

--- a/pickaladder/templates/dashboard.html
+++ b/pickaladder/templates/dashboard.html
@@ -76,7 +76,7 @@
                 </div>
 
                 <div class="dashboard-column-right">
-                    <div class="competition-stack d-flex flex-column gap-4">
+                    <div class="competition-stack flex-column gap-4">
                         
                         {% if requests %}
                         <div class="card card-compact">

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -143,7 +143,7 @@
 
         {# Right Column: Competition Stack #}
         <div class="dashboard-column-right">
-            <div class="competition-stack d-flex flex-column gap-4">
+            <div class="competition-stack flex-column gap-4">
                 {# Competitions Hub #}
                 <div class="competitions-hub">
                     <h3 class="sidebar-header">Competitions</h3>


### PR DESCRIPTION
Perform a "Clean Sweep" of the Dashboard layout to stop the Competition and Social cards from overlapping.
1. HTML Cleanup: Remove inline width from tournament cards and legacy flex from dashboard columns.
2. CSS Enforcement: Enforce 1fr 350px grid and add overflow:hidden to columns.
3. Badge Normalization: Enforce 1:1 aspect ratio on circular badges.

Fixes #1395

---
*PR created automatically by Jules for task [13202201920026818332](https://jules.google.com/task/13202201920026818332) started by @brewmarsh*