### PR TITLE
Fix Community Hub mobile layout overlap

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -117,6 +117,20 @@
     margin-bottom: 0 !important;
 }
 
+/* --- Responsive Flex Utilities --- */
+.flex-column { flex-direction: column !important; }
+.flex-row { flex-direction: row !important; }
+
+@media (min-width: 768px) {
+    .flex-md-column { flex-direction: column !important; }
+    .flex-md-row { flex-direction: row !important; }
+    .w-md-auto { width: auto !important; }
+    .align-items-md-center { align-items: center !important; }
+}
+
+.flex-grow-1 { flex-grow: 1 !important; }
+.align-items-stretch { align-items: stretch !important; }
+
 /* --- Responsive Visibility Utilities --- */
 body .d-none { display: none !important; }
 

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -2,9 +2,9 @@
 {% from "components/_empty_state.html" import empty_state %}
 {% block title %}Community Hub{% endblock %}
 {% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+<div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center justify-content-between mb-4 gap-3">
     <h1 class="mb-0">Community Hub</h1>
-    <button id="invite-friend-btn" class="btn btn-primary w-auto btn-action" data-csrf="{{ csrf_token() }}">
+    <button id="invite-friend-btn" class="btn btn-primary w-100 w-md-auto btn-action" data-csrf="{{ csrf_token() }}">
         <i class="fas fa-user-plus me-1"></i> Invite Friend
     </button>
 </div>
@@ -60,12 +60,14 @@
 {# 2. SEARCH BAR #}
 <div class="mx-auto mb-5" style="max-width: 600px;">
     <form method="get" action="{{ url_for('user.view_community') }}" class="search-form">
-        <div class="input-group">
-            <input type="text" name="search" class="form-control" placeholder="Search by username, name, or email" value="{{ search_term }}">
-            <button type="submit" class="btn btn-primary">Search</button>
-            {% if search_term %}
-            <a href="{{ url_for('user.view_community') }}" class="btn btn-secondary">Clear</a>
-            {% endif %}
+        <div class="input-group flex-column flex-md-row">
+            <input type="text" name="search" class="form-control w-100 w-md-auto flex-grow-1" placeholder="Search by username, name, or email" value="{{ search_term }}">
+            <div class="d-flex gap-2 w-100 w-md-auto">
+                <button type="submit" class="btn btn-primary flex-grow-1">Search</button>
+                {% if search_term %}
+                <a href="{{ url_for('user.view_community') }}" class="btn btn-secondary flex-grow-1">Clear</a>
+                {% endif %}
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
The Community Hub page had a broken layout on mobile where the title and 'Invite Friend' button overlapped. I've updated the templates to use responsive flex utilities that stack these elements vertically on screens smaller than 768px. I also improved the search bar's responsiveness to ensure it remains usable on narrow viewports. New CSS utility classes for responsive flex-direction and widths were added to `layout-utils.css` to support these changes.

Fixes #1406

---
*PR created automatically by Jules for task [12503511638427532280](https://jules.google.com/task/12503511638427532280) started by @brewmarsh*