### PR TITLE
Fix Safari Clipboard Error and Refactor Share Logic

### DIFF
--- a/pickaladder/static/js/main.js
+++ b/pickaladder/static/js/main.js
@@ -22,6 +22,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Handle flash messages
     handleFlashMessages();
+
+    // Global click handler for clickable rows
+    document.addEventListener("click", (e) => {
+        const row = e.target.closest(".clickable-row");
+        if (row && row.dataset.href && !e.target.closest("a") && !e.target.closest("button") && !e.target.closest("input")) {
+            window.location.href = row.dataset.href;
+        }
+    });
 });
 
 function handleFlashMessages() {
@@ -64,4 +72,154 @@ function handleFlashMessages() {
             }
         }
     });
+}
+
+/**
+ * Copies a canvas image to the clipboard.
+ * Optimized for Safari's asynchronous clipboard security model.
+ */
+function copyCanvasToClipboard(canvas, buttonEl) {
+    try {
+        // Safari Fix: Instead of awaiting the blob, we pass a function that returns
+        // a Promise for the blob directly into the ClipboardItem dictionary.
+        // This keeps the navigator.clipboard.write call synchronous within the user gesture.
+        const clipboardItem = new ClipboardItem({
+            "image/png": () => new Promise((resolve, reject) => {
+                if (!canvas.toBlob) {
+                    reject(new Error("Canvas.toBlob not supported"));
+                    return;
+                }
+                canvas.toBlob(blob => {
+                    if (blob) resolve(blob);
+                    else reject(new Error("Canvas toBlob failed"));
+                }, 'image/png');
+            })
+        });
+
+        navigator.clipboard.write([clipboardItem]).then(() => {
+            if (typeof showToast === 'function') {
+                showToast("Image copied to clipboard!", "success");
+            }
+
+            if (buttonEl) {
+                const originalContent = buttonEl.innerHTML;
+                buttonEl.innerHTML = '<i class="fas fa-check"></i> Copied!';
+                setTimeout(() => {
+                    buttonEl.innerHTML = originalContent;
+                }, 2000);
+            }
+        }).catch(err => {
+            console.error('Clipboard write failed, falling back to download:', err);
+            fallbackToDownload(canvas, buttonEl);
+        });
+    } catch (err) {
+        console.error('Clipboard API failed, falling back to download:', err);
+        fallbackToDownload(canvas, buttonEl);
+    }
+}
+
+/**
+ * Fallback to downloading the image if clipboard write fails.
+ */
+function fallbackToDownload(canvas, buttonEl) {
+    downloadCanvas(canvas, 'match-result.png');
+    if (typeof showToast === 'function') {
+        showToast("Saved image to your device!", "success");
+    }
+}
+
+function downloadCanvas(canvas, filename) {
+    const link = document.createElement('a');
+    link.download = filename || 'share-card.png';
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+}
+
+function dismissToast(toast) {
+    if (!toast || !toast.parentNode) return;
+    toast.classList.add('fade-out');
+    setTimeout(() => {
+        if (toast.parentNode) {
+            toast.remove();
+        }
+    }, 500);
+}
+
+function showToast(message, category = 'info', submissionId = null) {
+    const toastContainer = document.querySelector('.toast-container');
+    if (!toastContainer) return;
+
+    const toastId = submissionId || `toast_${Date.now()}`;
+    const isTesting = document.body.dataset.isTesting === 'true';
+    const autohide = category !== 'info' && !isTesting; // Don't autohide pending toasts or in tests
+    const delay = 4000;
+    const logoUrl = document.body.dataset.logoUrl || '/static/pickaladder_logo_64.png';
+
+    let progressBar = '';
+    if (category === 'info') {
+        progressBar = '<div class="progress"><div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div></div>';
+    }
+
+    const toastHTML = `
+        <div class="toast show alert-${category}" id="${toastId}" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+                <img src="${logoUrl}" class="rounded mr-2" alt="Logo" style="width: 20px; height: 20px;">
+                <strong>pickaladder</strong>
+                <button type="button" class="close" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="toast-body">
+                ${message}
+                ${progressBar}
+            </div>
+        </div>
+    `;
+    toastContainer.insertAdjacentHTML('beforeend', toastHTML);
+    const newToast = document.getElementById(toastId);
+
+    // Handle close button
+    const closeBtn = newToast.querySelector('.close');
+    closeBtn.onclick = () => dismissToast(newToast);
+
+    // Auto-dismiss
+    if (autohide) {
+        setTimeout(() => dismissToast(newToast), delay);
+    }
+
+    return toastId;
+}
+
+function updateToast(toastId, message, category) {
+    const toastElement = document.getElementById(toastId);
+    if (!toastElement) return;
+
+    const toastBody = toastElement.querySelector('.toast-body');
+
+    // Remove progress bar
+    const progressBar = toastBody.querySelector('.progress');
+    if (progressBar) {
+        progressBar.remove();
+    }
+
+    toastBody.innerHTML = message;
+
+    // Add a retry button for failed submissions
+    if (category === 'danger') {
+        const retryButton = document.createElement('button');
+        retryButton.className = 'btn btn-sm btn-link';
+        retryButton.innerText = 'Retry';
+        retryButton.onclick = function () {
+            if (window.optimisticSubmission) {
+                window.optimisticSubmission.retrySubmission(toastId);
+            }
+        };
+        toastBody.appendChild(document.createElement('br'));
+        toastBody.appendChild(retryButton);
+    }
+
+    // Start auto-dismiss now that it's no longer "pending"
+    if (category !== 'info') {
+        setTimeout(() => dismissToast(toastElement), 4000);
+    }
 }

--- a/pickaladder/templates/layout.html
+++ b/pickaladder/templates/layout.html
@@ -38,7 +38,8 @@
 
 <body class="{% if g.user and g.user.dark_mode %}dark-mode{% endif %}"
     {% if g.user and g.user.dark_mode %}data-theme="dark" {% endif %}
-    {% if is_testing %}data-is-testing="true" {% endif %}>
+    data-is-testing="{{ 'true' if is_testing else 'false' }}"
+    data-logo-url="{{ url_for('static', filename='pickaladder_logo_64.png') }}">
     {% if config['FLASK_ENV'] == 'beta' %}
     <div class="alert alert-primary text-center m-0"
         style="background-color: var(--primary-color); color: white; border: none; border-radius: 0;">
@@ -105,134 +106,6 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-    <script>
-
-        async function copyCanvasToClipboard(canvas, buttonEl) {
-            try {
-                const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
-                await navigator.clipboard.write([
-                    new ClipboardItem({ "image/png": blob })
-                ]);
-
-                if (typeof showToast === 'function') {
-                    showToast("Image copied to clipboard!", "success");
-                }
-
-                if (buttonEl) {
-                    const originalContent = buttonEl.innerHTML;
-                    buttonEl.innerHTML = '<i class="fas fa-check"></i> Copied!';
-                    setTimeout(() => {
-                        buttonEl.innerHTML = originalContent;
-                    }, 2000);
-                }
-            } catch (err) {
-                console.error('Failed to copy: ', err);
-                if (typeof showToast === 'function') {
-                    showToast("Unable to copy image. Please use Download instead.", "danger");
-                }
-            }
-        }
-
-        function downloadCanvas(canvas, filename) {
-            const link = document.createElement('a');
-            link.download = filename || 'share-card.png';
-            link.href = canvas.toDataURL('image/png');
-            link.click();
-        }
-
-        function dismissToast(toast) {
-            if (!toast || !toast.parentNode) return;
-            toast.classList.add('fade-out');
-            setTimeout(() => {
-                if (toast.parentNode) {
-                    toast.remove();
-                }
-            }, 500);
-        }
-
-        function showToast(message, category = 'info', submissionId = null) {
-            const toastContainer = document.querySelector('.toast-container');
-            if (!toastContainer) return;
-
-            const toastId = submissionId || `toast_${Date.now()}`;
-            const autohide = category !== 'info' && !{{ is_testing|tojson }}; // Don't autohide pending toasts or in tests
-            const delay = 4000;
-
-            let progressBar = '';
-            if (category === 'info') {
-                progressBar = '<div class="progress"><div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div></div>';
-            }
-
-            const toastHTML = `
-                <div class="toast show alert-${category}" id="${toastId}" role="alert" aria-live="assertive" aria-atomic="true">
-                    <div class="toast-header">
-                        <img src="{{ url_for('static', filename='pickaladder_logo_64.png') }}" class="rounded mr-2" alt="Logo" style="width: 20px; height: 20px;">
-                        <strong>pickaladder</strong>
-                        <button type="button" class="close" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="toast-body">
-                        ${message}
-                        ${progressBar}
-                    </div>
-                </div>
-            `;
-            toastContainer.insertAdjacentHTML('beforeend', toastHTML);
-            const newToast = document.getElementById(toastId);
-
-            // Handle close button
-            const closeBtn = newToast.querySelector('.close');
-            closeBtn.onclick = () => dismissToast(newToast);
-
-            // Auto-dismiss
-            if (autohide) {
-                setTimeout(() => dismissToast(newToast), delay);
-            }
-
-            return toastId;
-        }
-
-        function updateToast(toastId, message, category) {
-            const toastElement = document.getElementById(toastId);
-            if (!toastElement) return;
-
-            const toastBody = toastElement.querySelector('.toast-body');
-
-            // Remove progress bar
-            const progressBar = toastBody.querySelector('.progress');
-            if (progressBar) {
-                progressBar.remove();
-            }
-
-            toastBody.innerHTML = message;
-
-            // Add a retry button for failed submissions
-            if (category === 'danger') {
-                const retryButton = document.createElement('button');
-                retryButton.className = 'btn btn-sm btn-link';
-                retryButton.innerText = 'Retry';
-                retryButton.onclick = function () {
-                    window.optimisticSubmission.retrySubmission(toastId);
-                };
-                toastBody.appendChild(document.createElement('br'));
-                toastBody.appendChild(retryButton);
-            }
-
-            // Start auto-dismiss now that it's no longer "pending"
-            if (category !== 'info') {
-                setTimeout(() => dismissToast(toastElement), 4000);
-            }
-        }
-
-        document.addEventListener("click", (e) => {
-            const row = e.target.closest(".clickable-row");
-            if (row && row.dataset.href && !e.target.closest("a") && !e.target.closest("button") && !e.target.closest("input")) {
-                window.location.href = row.dataset.href;
-            }
-        });
-
-    </script>
     <script src="{{ url_for('static', filename='js/navbar.js') }}"></script>
 
     <script>


### PR DESCRIPTION
This PR fixes a known issue where users on iOS Safari were unable to share match results to the clipboard due to a security violation error. The current implementation awaited a canvas blob before calling the Clipboard API, which broke the user gesture context in Safari.

The fix involves using the modern `ClipboardItem` constructor with a function returning a Promise, ensuring the execution remains synchronous within the user gesture context according to Safari's requirements.

Additionally, I've moved the associated utility functions (toast system, canvas downloading, etc.) from `layout.html` to `main.js` and ensured that application-level flags (like testing mode) are properly communicated to the static JavaScript file via data attributes on the `<body>` element.

Testing performed:
- Verified the fix using a Playwright script with a mock page to confirm the UI feedback and fallback logic.
- Ran existing E2E tests (`pytest tests/e2e/test_e2e.py`) to ensure no regressions in common user flows.

Fixes #1417

---
*PR created automatically by Jules for task [8893794603235805032](https://jules.google.com/task/8893794603235805032) started by @brewmarsh*