### PR TITLE
Fix Friend Request Card Mobile Layout

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -120,12 +120,22 @@
 /* --- Responsive Flex Utilities --- */
 .flex-column { flex-direction: column !important; }
 .flex-row { flex-direction: row !important; }
+.flex-wrap { flex-wrap: wrap !important; }
+.flex-shrink-0 { flex-shrink: 0 !important; }
+
+.mt-1 { margin-top: 0.25rem !important; }
+.mt-2 { margin-top: 0.5rem !important; }
+
+@media (min-width: 576px) {
+    .mt-sm-0 { margin-top: 0 !important; }
+}
 
 @media (min-width: 768px) {
     .flex-md-column { flex-direction: column !important; }
     .flex-md-row { flex-direction: row !important; }
     .w-md-auto { width: auto !important; }
     .align-items-md-center { align-items: center !important; }
+    .mt-md-0 { margin-top: 0 !important; }
 }
 
 .flex-grow-1 { flex-grow: 1 !important; }

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -37,14 +37,14 @@
                         </div>
                     </td>
                     <td data-label="Actions" style="text-align: right;">
-                        <div class="d-flex justify-content-end gap-2 flex-wrap">
+                        <div class="d-flex justify-content-end gap-2 flex-wrap mt-2 mt-md-0">
                             <form action="{{ url_for('user.accept_request', requester_id=request.id) }}" method="post">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="btn btn-primary btn-sm">Accept</button>
+                                <button type="submit" class="btn btn-primary btn-sm flex-shrink-0">Accept</button>
                             </form>
                             <form action="{{ url_for('user.cancel_request', target_id=request.id) }}" method="post">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="btn btn-secondary btn-sm"
+                                <button type="submit" class="btn btn-secondary btn-sm flex-shrink-0"
                                     onclick="return confirm('Are you sure you want to decline this friend request?');">Decline</button>
                             </form>
                         </div>

--- a/pickaladder/templates/dashboard.html
+++ b/pickaladder/templates/dashboard.html
@@ -83,9 +83,9 @@
                             <h3 class="sidebar-header">Requests</h3>
                             <div class="list-group list-group-flush">
                                 {% for request in requests %}
-                                <div class="list-group-item d-flex justify-content-between align-items-center py-2 px-0 border-bottom">
-                                    <span class="small">{{ request[1] }}</span>
-                                    <div class="d-flex gap-1">
+                                <div class="list-group-item d-flex flex-wrap justify-content-between align-items-center py-2 px-0 border-bottom gap-2">
+                                    <span class="small flex-grow-1">{{ request[1] }}</span>
+                                    <div class="d-flex gap-1 flex-shrink-0 mt-1 mt-sm-0">
                                         <form action="{{ url_for('user.accept_friend_request', friend_id=request[0]) }}" method="post">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-sm btn-volt p-1 px-2">✓</button>

--- a/pickaladder/templates/friends/index.html
+++ b/pickaladder/templates/friends/index.html
@@ -34,17 +34,17 @@
                         </div>
                     </td>
                     <td data-label="Actions" style="text-align: right;">
-                        <form action="{{ url_for('user.accept_request', requester_id=request.id) }}" method="post"
-                            style="display: inline;">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <button type="submit" class="btn">Accept</button>
-                        </form>
-                        <form action="{{ url_for('user.cancel_request', target_id=request.id) }}" method="post"
-                            style="display: inline;">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <button type="submit" class="btn btn-outline-danger"
-                                onclick="return confirm('Are you sure you want to decline this friend request?');">Decline</button>
-                        </form>
+                        <div class="d-flex justify-content-end gap-2 flex-wrap mt-2 mt-md-0">
+                            <form action="{{ url_for('user.accept_request', requester_id=request.id) }}" method="post">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn flex-shrink-0">Accept</button>
+                            </form>
+                            <form action="{{ url_for('user.cancel_request', target_id=request.id) }}" method="post">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-outline-danger flex-shrink-0"
+                                    onclick="return confirm('Are you sure you want to decline this friend request?');">Decline</button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
                 {% endfor %}

--- a/pickaladder/templates/user/requests.html
+++ b/pickaladder/templates/user/requests.html
@@ -29,17 +29,17 @@
                         </div>
                     </td>
                     <td data-label="Actions" style="text-align: right;">
-                        <form action="{{ url_for('user.accept_request', requester_id=request_user.id) }}" method="post"
-                            style="display: inline;">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <button type="submit" class="btn btn-primary">Confirm</button>
-                        </form>
-                        <form action="{{ url_for('user.cancel_request', target_id=request_user.id) }}" method="post"
-                            style="display: inline;">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <button type="submit" class="btn btn-outline-danger"
-                                onclick="return confirm('Are you sure you want to decline this friend request?');">Decline</button>
-                        </form>
+                        <div class="d-flex justify-content-end gap-2 flex-wrap mt-2 mt-md-0">
+                            <form action="{{ url_for('user.accept_request', requester_id=request_user.id) }}" method="post">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-primary flex-shrink-0">Confirm</button>
+                            </form>
+                            <form action="{{ url_for('user.cancel_request', target_id=request_user.id) }}" method="post">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-outline-danger flex-shrink-0"
+                                    onclick="return confirm('Are you sure you want to decline this friend request?');">Decline</button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
                 {% endfor %}

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -209,15 +209,17 @@
                                 {% for request in requests %}
                                 <tr>
                                     <td class="p-2">
-                                        <a href="{{ url_for('user.view_user', user_id=request.id) }}"
-                                            class="fs-xs">{{ request.username }}</a>
-                                    </td>
-                                    <td class="p-2 text-right">
-                                        <form action="{{ url_for('user.accept_request', requester_id=request.id) }}"
-                                            method="post" class="d-inline">
-                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                            <button type="submit" class="btn btn-volt btn-sm py-1 px-2 fs-xxs w-auto text-none">Accept</button>
-                                        </form>
+                                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                                            <a href="{{ url_for('user.view_user', user_id=request.id) }}"
+                                                class="fs-xs flex-grow-1">{{ request.username }}</a>
+                                            <div class="flex-shrink-0 mt-1 mt-sm-0">
+                                                <form action="{{ url_for('user.accept_request', requester_id=request.id) }}"
+                                                    method="post" class="d-inline">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                    <button type="submit" class="btn btn-volt btn-sm py-1 px-2 fs-xxs w-auto text-none flex-shrink-0">Accept</button>
+                                                </form>
+                                            </div>
+                                        </div>
                                     </td>
                                 </tr>
                                 {% endfor %}


### PR DESCRIPTION
This change fixes the mobile layout of Friend Request cards and list items across the application. On small screens, the action buttons (Accept/Decline/Cancel) were previously being squished because they were forced onto the same line as the user's name. 

Key improvements:
- **Responsive Wrapping:** Added `flex-wrap` to the parent containers so buttons can cleanly drop below the name on narrow screens.
- **Button Protection:** Wrapped buttons in a `flex-shrink-0` container to ensure they remain tappable and do not shrink.
- **Spacing:** Added responsive top margins (`mt-1` or `mt-2`) that only apply when the buttons wrap, providing necessary vertical separation.
- **Consistency:** Applied these fixes to all relevant templates, including `community.html`, `dashboard.html`, `user_dashboard.html`, and others.
- **Utilities:** Added missing utility classes to `layout-utils.css` to support these and future responsive layout needs.

Fixes #1407

---
*PR created automatically by Jules for task [18444408125277010709](https://jules.google.com/task/18444408125277010709) started by @brewmarsh*