### PR TITLE
Add Universal Responsive Layout Utilities

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -347,3 +347,41 @@ body .d-none { display: none !important; }
     white-space: nowrap !important;
     border: 0 !important;
 }
+
+/* --- Universal Responsive Utilities --- */
+.responsive-header-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: stretch;
+}
+
+.responsive-card-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 16px;
+}
+
+.w-100-mobile {
+    width: 100% !important;
+}
+
+@media (min-width: 768px) {
+    .responsive-header-stack {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .responsive-card-stack {
+        flex-direction: row;
+        text-align: left;
+        align-items: center;
+    }
+
+    .w-100-mobile {
+        width: auto !important;
+    }
+}

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -2,9 +2,9 @@
 {% from "components/_empty_state.html" import empty_state %}
 {% block title %}Community Hub{% endblock %}
 {% block content %}
-<div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center justify-content-between mb-4 gap-3">
+<div class="responsive-header-stack mb-4">
     <h1 class="mb-0">Community Hub</h1>
-    <button id="invite-friend-btn" class="btn btn-primary w-100 w-md-auto btn-action" data-csrf="{{ csrf_token() }}">
+    <button id="invite-friend-btn" class="btn btn-primary w-100-mobile btn-action" data-csrf="{{ csrf_token() }}">
         <i class="fas fa-user-plus me-1"></i> Invite Friend
     </button>
 </div>

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block title %}{{ group.name }}{% endblock %}
 {% block content %}
-<div class="card hero-stats-card">
+<div class="card hero-stats-card responsive-card-stack">
     {% if group.ownerRef.id == g.user['uid'] %}
     <a href="{{ url_for('group.edit_group', group_id=group.id) }}" title="Group Settings" class="btn-edit-gear"
         data-testid="group-settings-btn">⚙️</a>
@@ -34,12 +34,12 @@
 
     <div class="hero-right-panel">
         {% if is_member %}
-        <div class="d-flex gap-2">
-            <button type="button" class="btn btn-outline-primary w-auto" data-toggle="modal"
+        <div class="d-flex flex-column flex-md-row gap-2 w-100-mobile">
+            <button type="button" class="btn btn-outline-primary w-100-mobile" data-toggle="modal"
                 data-target="#shareGroupModal">
                 <i class="fas fa-share-alt"></i> Share
             </button>
-            <a href="{{ url_for('match.record_match', group_id=group.id) }}" class="btn btn-volt w-auto">Record a Match</a>
+            <a href="{{ url_for('match.record_match', group_id=group.id) }}" class="btn btn-volt w-100-mobile">Record a Match</a>
         </div>
         {% endif %}
     </div>

--- a/pickaladder/templates/groups.html
+++ b/pickaladder/templates/groups.html
@@ -3,9 +3,9 @@
 {% block title %}Groups{% endblock %}
 {% block content %}
 <div class="container">
-    <div class="d-flex justify-content-between align-items-center mb-4 page-header-actions">
+    <div class="responsive-header-stack mb-4 page-header-actions">
         <h1>Groups</h1>
-        <a href="{{ url_for('group.create_group') }}" class="btn btn-primary btn-action">
+        <a href="{{ url_for('group.create_group') }}" class="btn btn-primary w-100-mobile btn-action">
             <i class="fas fa-plus-circle"></i> Create Group
         </a>
     </div>

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -308,7 +308,7 @@ class GroupRoutesFirebaseTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Groups</h1>", response.data)
         self.assertIn(
-            b"d-flex justify-content-between align-items-center mb-4", response.data
+            b"responsive-header-stack mb-4 page-header-actions", response.data
         )
         self.assertIn(b"btn btn-primary", response.data)
         self.assertIn(b"Create Group", response.data)


### PR DESCRIPTION
This PR introduces a set of systemic responsive layout utilities designed to replace rigid horizontal flex rows. These utilities ensure that headers and cards stack vertically on mobile devices while maintaining their side-by-side layout on desktop.

Key changes:
- New CSS classes in `layout-utils.css` for responsive stacking and full-width mobile elements.
- Refactored `community.html` and `groups.html` headers to use `.responsive-header-stack`.
- Refactored the Group Details hero card in `group.html` to use `.responsive-card-stack` and responsive action buttons.
- Updated unit tests to match the new DOM structure.

Fixes #1413

---
*PR created automatically by Jules for task [7348769248826260407](https://jules.google.com/task/7348769248826260407) started by @brewmarsh*