### PR TITLE
Fix Groups mobile layout overlap

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -1,6 +1,7 @@
 /* --- 0. Layout Utilities --- */
 .w-auto { width: auto !important; }
 .mx-auto { margin-left: auto !important; margin-right: auto !important; }
+.gap-3 { gap: 1rem !important; }
 .gap-4 { gap: 1.5rem !important; }
 .justify-content-center { justify-content: center !important; }
 .text-center { text-align: center !important; }

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -2,9 +2,9 @@
 {% from "components/_empty_state.html" import empty_state %}
 {% block title %}Community Hub{% endblock %}
 {% block content %}
-<div class="responsive-header-stack mb-4">
+<div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center justify-content-between gap-3 mb-4">
     <h1 class="mb-0">Community Hub</h1>
-    <button id="invite-friend-btn" class="btn btn-primary w-100-mobile btn-action" data-csrf="{{ csrf_token() }}">
+    <button id="invite-friend-btn" class="btn btn-primary w-100 w-md-auto btn-action" data-csrf="{{ csrf_token() }}">
         <i class="fas fa-user-plus me-1"></i> Invite Friend
     </button>
 </div>

--- a/pickaladder/templates/groups.html
+++ b/pickaladder/templates/groups.html
@@ -3,9 +3,9 @@
 {% block title %}Groups{% endblock %}
 {% block content %}
 <div class="container">
-    <div class="responsive-header-stack mb-4 page-header-actions">
+    <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center justify-content-between gap-3 mb-4 page-header-actions">
         <h1>Groups</h1>
-        <a href="{{ url_for('group.create_group') }}" class="btn btn-primary w-100-mobile btn-action">
+        <a href="{{ url_for('group.create_group') }}" class="btn btn-primary w-100 w-md-auto btn-action">
             <i class="fas fa-plus-circle"></i> Create Group
         </a>
     </div>

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -308,7 +308,8 @@ class GroupRoutesFirebaseTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Groups</h1>", response.data)
         self.assertIn(
-            b"responsive-header-stack mb-4 page-header-actions", response.data
+            b"d-flex flex-column flex-md-row align-items-stretch align-items-md-center justify-content-between gap-3 mb-4 page-header-actions",
+            response.data,
         )
         self.assertIn(b"btn btn-primary", response.data)
         self.assertIn(b"Create Group", response.data)


### PR DESCRIPTION
This change fixes the mobile layout overlap on the Groups page where the 'Create Group' button was colliding with the page title. 

Key changes:
1. **Utility Update**: Added `.gap-3 { gap: 1rem !important; }` to `pickaladder/static/css/layout-utils.css` to provide standard spacing between stacked elements.
2. **Template Refactoring**: 
   - Refactored the header containers in `groups.html` and `community.html` to use explicit flexbox utilities (`d-flex flex-column flex-md-row align-items-stretch align-items-md-center justify-content-between gap-3 mb-4`). This ensures the title and action button stack vertically on screens under 768px.
   - Updated the "Create Group" and "Invite Friend" buttons to use `w-100 w-md-auto`, ensuring they take full width on mobile for better tap targets and auto width on desktop.
3. **Test Maintenance**: Updated `tests/test_group.py` to assert the presence of the new responsive utility classes in the rendered HTML.

These updates provide a cleaner, more accessible mobile experience and prevent layout 'squishing' in header sections.

Fixes #1411

---
*PR created automatically by Jules for task [12846164974611931006](https://jules.google.com/task/12846164974611931006) started by @brewmarsh*