### PR TITLE
Add Loading Spinner to Share Buttons

### DIFF
--- a/pickaladder/static/js/main.js
+++ b/pickaladder/static/js/main.js
@@ -141,10 +141,39 @@ function handleFlashMessages() {
 }
 
 /**
+ * Handles the "Share" button click: shows a loading state, captures the element,
+ * and copies the resulting image to the clipboard.
+ * @param {string} buttonId - The ID of the button that was clicked.
+ * @param {string} targetElementId - The ID of the element to capture as an image.
+ */
+async function handleShareClick(buttonId, targetElementId) {
+    const buttonEl = document.getElementById(buttonId);
+    if (!buttonEl) return;
+
+    const originalHTML = buttonEl.innerHTML;
+    buttonEl.disabled = true;
+    buttonEl.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Generating...';
+
+    try {
+        const canvas = await captureElement(targetElementId);
+        await copyCanvasToClipboard(canvas, buttonEl, originalHTML);
+    } catch (err) {
+        console.error('Share failed:', err);
+        buttonEl.innerHTML = originalHTML;
+    } finally {
+        buttonEl.disabled = false;
+    }
+}
+
+/**
  * Copies a canvas image to the clipboard.
  * Optimized for Safari's asynchronous clipboard security model.
+ * @param {HTMLCanvasElement} canvas - The canvas to copy.
+ * @param {HTMLElement} buttonEl - Optional button element to show success state on.
+ * @param {string} originalHTML - Optional original HTML to restore after success.
+ * @returns {Promise<void>}
  */
-function copyCanvasToClipboard(canvas, buttonEl) {
+function copyCanvasToClipboard(canvas, buttonEl, originalHTML) {
     try {
         // Safari Fix: Instead of awaiting the blob, we pass a function that returns
         // a Promise for the blob directly into the ClipboardItem dictionary.
@@ -162,35 +191,41 @@ function copyCanvasToClipboard(canvas, buttonEl) {
             })
         });
 
-        navigator.clipboard.write([clipboardItem]).then(() => {
+        return navigator.clipboard.write([clipboardItem]).then(() => {
             if (typeof showToast === 'function') {
                 showToast("Image copied to clipboard!", "success");
             }
 
             if (buttonEl) {
-                const originalContent = buttonEl.innerHTML;
+                const contentToRestore = originalHTML || buttonEl.innerHTML;
                 buttonEl.innerHTML = '<i class="fas fa-check"></i> Copied!';
                 setTimeout(() => {
-                    buttonEl.innerHTML = originalContent;
+                    buttonEl.innerHTML = contentToRestore;
                 }, 2000);
             }
         }).catch(err => {
             console.error('Clipboard write failed, falling back to download:', err);
-            fallbackToDownload(canvas, buttonEl);
+            return fallbackToDownload(canvas, buttonEl, originalHTML);
         });
     } catch (err) {
         console.error('Clipboard API failed, falling back to download:', err);
-        fallbackToDownload(canvas, buttonEl);
+        return fallbackToDownload(canvas, buttonEl, originalHTML);
     }
 }
 
 /**
  * Fallback to downloading the image if clipboard write fails.
+ * @param {HTMLCanvasElement} canvas - The canvas to download.
+ * @param {HTMLElement} buttonEl - Optional button element to restore.
+ * @param {string} originalHTML - Optional original HTML to restore.
  */
-function fallbackToDownload(canvas, buttonEl) {
+function fallbackToDownload(canvas, buttonEl, originalHTML) {
     downloadCanvas(canvas, 'match-result.png');
     if (typeof showToast === 'function') {
         showToast("Saved image to your device!", "success");
+    }
+    if (buttonEl && originalHTML) {
+        buttonEl.innerHTML = originalHTML;
     }
 }
 

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -462,10 +462,10 @@
                 </div>
                 <div class="mt-4 text-center">
                     <div class="d-flex justify-content-center gap-2 mb-3">
-                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="copyCard('bragCardContainer', this)">
+                        <button type="button" class="btn btn-outline-secondary btn-action" id="copyBragCardBtn" onclick="handleShareClick('copyBragCardBtn', 'bragCardContainer')">
                             <i class="fas fa-clipboard"></i> Copy Image
                         </button>
-                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="downloadCard('bragCardContainer', 'brag-card.png')">
+                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="downloadCard('bragCardContainer', 'brag-card.png', this)">
                             <i class="fas fa-download"></i> Download
                         </button>
                     </div>
@@ -508,10 +508,10 @@
                     </div>
                     <div id="qrcode" class="d-flex justify-content-center mt-3" style="background: white; padding: 10px; border-radius: 10px; width: fit-content; margin-left: auto; margin-right: auto;"></div>
                     <div class="d-flex justify-content-center gap-2 mb-3 mt-3">
-                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="copyCard('groupShareCardContainer', this)">
+                        <button type="button" class="btn btn-outline-secondary btn-action" id="copyGroupCardBtn" onclick="handleShareClick('copyGroupCardBtn', 'groupShareCardContainer')">
                             <i class="fas fa-clipboard"></i> Copy Image
                         </button>
-                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="downloadCard('groupShareCardContainer', 'group-card.png')">
+                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="downloadCard('groupShareCardContainer', 'group-card.png', this)">
                             <i class="fas fa-download"></i> Download
                         </button>
                     </div>
@@ -679,19 +679,7 @@
         });
     }
 
-    async function copyCard(containerId, buttonEl) {
-        const original = showButtonSpinner(buttonEl);
-        try {
-            const canvas = await captureElement(containerId);
-            hideButtonSpinner(buttonEl, original);
-            await copyCanvasToClipboard(canvas, buttonEl);
-        } catch (err) {
-            console.error('Capture failed:', err);
-            hideButtonSpinner(buttonEl, original);
-        }
-    }
-
-    async function downloadCard(containerId, filename) {
+    async function downloadCard(containerId, filename, buttonEl) {
         const original = showButtonSpinner(buttonEl);
         try {
             const canvas = await captureElement(containerId);

--- a/pickaladder/templates/match/summary.html
+++ b/pickaladder/templates/match/summary.html
@@ -189,10 +189,10 @@
                 </div>
                 <div class="mt-4 text-center">
                     <div class="d-flex justify-content-center gap-2 mb-3">
-                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="copyCard('matchShareCardContainer', this)">
+                        <button type="button" class="btn btn-outline-secondary btn-action" id="copyMatchCardBtn" onclick="handleShareClick('copyMatchCardBtn', 'matchShareCardContainer')">
                             <i class="fas fa-clipboard"></i> Copy Image
                         </button>
-                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="downloadCard('matchShareCardContainer', 'match-card.png')">
+                        <button type="button" class="btn btn-outline-secondary btn-action" onclick="downloadCard('matchShareCardContainer', 'match-card.png', this)">
                             <i class="fas fa-download"></i> Download
                         </button>
                     </div>
@@ -214,19 +214,7 @@
 </style>
 
 <script>
-    async function copyCard(containerId, buttonEl) {
-        const original = showButtonSpinner(buttonEl);
-        try {
-            const canvas = await captureElement(containerId);
-            hideButtonSpinner(buttonEl, original);
-            await copyCanvasToClipboard(canvas, buttonEl);
-        } catch (err) {
-            console.error('Capture failed:', err);
-            hideButtonSpinner(buttonEl, original);
-        }
-    }
-
-    async function downloadCard(containerId, filename) {
+    async function downloadCard(containerId, filename, buttonEl) {
         const original = showButtonSpinner(buttonEl);
         try {
             const canvas = await captureElement(containerId);


### PR DESCRIPTION
Implement a loading state and disable-toggle for the Share button while `html2canvas` generates the match summary image.

- Added `handleShareClick(buttonId, targetElementId)` in `main.js`.
- Updated `copyCanvasToClipboard` to return its promise for better orchestration.
- Updated `fallbackToDownload` to restore button state.
- Refactored `match/summary.html` and `group.html` to use the new centralized share handler.
- Fixed `downloadCard` in templates to correctly show the spinner by passing the button reference.

Fixes #1419

---
*PR created automatically by Jules for task [15859072118336631005](https://jules.google.com/task/15859072118336631005) started by @brewmarsh*