### PR TITLE
Refactor tournament and match forms for mobile-first responsiveness

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -385,3 +385,16 @@ body .d-none { display: none !important; }
         width: auto !important;
     }
 }
+
+/* --- Responsive Form Grid --- */
+.responsive-form-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+}
+
+@media (min-width: 768px) {
+    .responsive-form-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}

--- a/pickaladder/templates/match/edit_match.html
+++ b/pickaladder/templates/match/edit_match.html
@@ -22,13 +22,13 @@
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
                         <div class="row mb-4">
-                            <div class="col-6">
+                            <div class="col-12 col-md-6 mb-3 mb-md-0">
                                 <label for="player1_score" class="form-label">{{ player1_name }} Score</label>
                                 <input type="number" class="form-control form-control-lg text-center"
                                        id="player1_score" name="player1_score"
                                        value="{{ match.player1Score }}" min="0" required>
                             </div>
-                            <div class="col-6">
+                            <div class="col-12 col-md-6">
                                 <label for="player2_score" class="form-label">{{ player2_name }} Score</label>
                                 <input type="number" class="form-control form-control-lg text-center"
                                        id="player2_score" name="player2_score"

--- a/pickaladder/templates/tournaments/create_edit.html
+++ b/pickaladder/templates/tournaments/create_edit.html
@@ -11,7 +11,7 @@
         <form method="POST" enctype="multipart/form-data">
             {{ form.csrf_token }}
 
-            <div class="form-group">
+            <div class="form-group mb-3">
                 {{ form.name.label(class="form-label") }}
                 {{ form.name(class="form-input", placeholder="Summer Smash 2024") }}
                 {% if form.name.errors %}
@@ -21,7 +21,7 @@
                 {% endif %}
             </div>
 
-            <div class="form-group">
+            <div class="form-group mb-3">
                 {{ form.banner.label(class="form-label") }}
                 {% if tournament and tournament.banner_url %}
                     <div class="mb-2">
@@ -43,7 +43,7 @@
                 {% endif %}
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+            <div class="responsive-form-grid mb-3">
                 <div class="form-group">
                     {{ form.start_date.label(class="form-label") }}
                     {{ form.start_date(class="form-input", type="date") }}
@@ -64,7 +64,7 @@
                 </div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group mb-3">
                 {{ form.address.label(class="form-label") }}
                 {{ form.address(class="form-input", placeholder="123 Park Lane, New York, NY") }}
                 <small class="text-muted">This will generate a 'Get Directions' link for players.</small>
@@ -75,7 +75,7 @@
                 {% endif %}
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+            <div class="responsive-form-grid mb-3">
                 <div class="form-group">
                     {{ form.match_type.label(class="form-label") }}
                     <div class="segmented-control">
@@ -108,7 +108,7 @@
                 </div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group mb-3">
                 {{ form.description.label(class="form-label") }}
                 {{ form.description(class="form-input", rows="5", placeholder="Rules, schedule, and other details...") }}
                 {% if form.description.errors %}
@@ -130,13 +130,6 @@
     </div>
 </div>
 
-<style>
-@media screen and (max-width: 600px) {
-    div[style*="grid-template-columns: 1fr 1fr"] {
-        grid-template-columns: 1fr !important;
-    }
-}
-</style>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
This PR refactors the tournament creation/edit form and the match edit form to ensure that side-by-side inputs stack vertically on mobile devices. 

Key changes:
1.  **New CSS Utility**: Introduced `.responsive-form-grid` in `layout-utils.css` which provides a 1-column layout on mobile and 2-column on desktop.
2.  **Tournament Form**: Refactored `pickaladder/templates/tournaments/create_edit.html` to use this utility, replacing brittle inline grid styles and removing an ad-hoc media query.
3.  **Match Form**: Updated `pickaladder/templates/match/edit_match.html` to use `.col-12.col-md-6`, ensuring score inputs are easy to tap on mobile.
4.  **UX Improvements**: Added consistent bottom margins to form groups to maintain proper vertical rhythm and prevent cramped text on small screens.

Verified the fixes across mobile and desktop viewports using Playwright screenshots.

Fixes #1414

---
*PR created automatically by Jules for task [10766988675997908520](https://jules.google.com/task/10766988675997908520) started by @brewmarsh*