### PR TITLE
Fix Mobile Table Responsiveness and Leaderboard Grid

### DIFF
--- a/pickaladder/static/css/data-displays.css
+++ b/pickaladder/static/css/data-displays.css
@@ -158,3 +158,32 @@
     color: var(--danger-color);
     border-color: var(--danger-color);
 }
+
+/* Leaderboard */
+.leaderboard-row {
+    display: grid;
+    grid-template-columns: 50px 1fr 100px 100px 80px;
+    align-items: center;
+    padding: 10px 15px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.rank-1 { color: #FFD700; }
+.rank-2 { color: #C0C0C0; }
+.rank-3 { color: #CD7F32; }
+
+@media screen and (max-width: 768px) {
+    .leaderboard-row {
+        grid-template-columns: 50px 1fr;
+        gap: 8px;
+        padding: 12px 15px;
+    }
+
+    .leaderboard-row .leaderboard-stats {
+        grid-column: 2;
+        display: flex;
+        gap: 12px;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+    }
+}

--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -1,4 +1,5 @@
 /* --- 0. Layout Utilities --- */
+.table-responsive { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; margin-bottom: 1rem; }
 .w-auto { width: auto !important; }
 .mx-auto { margin-left: auto !important; margin-right: auto !important; }
 .gap-4 { gap: 1.5rem !important; }

--- a/pickaladder/static/dark.css
+++ b/pickaladder/static/dark.css
@@ -498,26 +498,6 @@ select:focus {
     background-color: var(--bg-color);
 }
 
-/* Leaderboard */
-.leaderboard-row {
-    display: grid;
-    grid-template-columns: 50px 1fr 100px 100px 80px;
-    align-items: center;
-    padding: 10px 15px;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.rank-1 {
-    color: #FFD700;
-}
-
-.rank-2 {
-    color: #C0C0C0;
-}
-
-.rank-3 {
-    color: #CD7F32;
-}
 
 /* Utilities */
 .d-flex {
@@ -601,10 +581,6 @@ select:focus {
         padding: 16px;
     }
 
-    .leaderboard-row {
-        display: flex;
-        justify-content: space-between;
-    }
 }
 
 /* Toasts */

--- a/pickaladder/templates/admin/admin.html
+++ b/pickaladder/templates/admin/admin.html
@@ -26,7 +26,8 @@
     <div class="card" style="grid-column: span 2;">
         <h3>User Management</h3>
         <div class="table-container">
-            <table class="table-standard responsive-table">
+            <div class="table-responsive">
+                <table class="table-standard responsive-table">
                 <thead>
                     <tr>
                         <th>User</th>
@@ -72,7 +73,8 @@
                     </tr>
                     {% endfor %}
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/pickaladder/templates/admin/style_guide.html
+++ b/pickaladder/templates/admin/style_guide.html
@@ -70,7 +70,8 @@
                 <div class="col-md-12 mb-4">
                     <h3>Match Row</h3>
                     <div class="table-container">
-                        <table class="table-standard">
+                        <div class="table-responsive">
+                            <table class="table-standard">
                             <thead>
                                 <tr>
                                     <th>Date</th>
@@ -83,7 +84,8 @@
                                     {% include "components/match_list_item.html" %}
                                 {% endwith %}
                             </tbody>
-                        </table>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/pickaladder/templates/admin_matches.html
+++ b/pickaladder/templates/admin_matches.html
@@ -11,7 +11,8 @@
     <input type="submit" value="Search" class="btn">
 </form>
 <div class="table-container">
-    <table class="table-standard responsive-table">
+    <div class="table-responsive">
+        <table class="table-standard responsive-table">
         <thead>
             <tr>
                 <th>Date</th>
@@ -26,6 +27,7 @@
                 {% include 'components/match_list_item.html' %}
             {% endfor %}
         </tbody>
-    </table>
+        </table>
+    </div>
 </div>
 {% endblock %}

--- a/pickaladder/templates/community.html
+++ b/pickaladder/templates/community.html
@@ -15,7 +15,8 @@
 <div class="card card-notification incoming-requests-section mb-4">
     <h4 class="card-header"><i class="fas fa-user-clock me-2"></i> Pending Friend Requests</h4>
     <div class="table-container mt-3">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>User</th>
@@ -52,7 +53,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
 </div>
 {% endif %}
@@ -77,7 +79,8 @@
 <div class="card requests-section" style="margin-top: 40px;">
     <h3>Sent Friend Requests</h3>
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>User</th>
@@ -109,7 +112,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
 </div>
 {% endif %}
@@ -119,7 +123,8 @@
 <div class="card tournament-invites-section" style="margin-bottom: 40px; border-left: 6px solid var(--primary-brand);">
     <h3>Tournament Invites</h3>
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>Tournament</th>
@@ -151,7 +156,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
 </div>
 {% endif %}
@@ -244,7 +250,8 @@
     <h3>Find Groups</h3>
     {% if public_groups %}
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th></th>
@@ -283,7 +290,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     {% else %}
     {{ empty_state(

--- a/pickaladder/templates/friends/index.html
+++ b/pickaladder/templates/friends/index.html
@@ -16,7 +16,8 @@
     {% if requests %}
     <h4>Received</h4>
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>User</th>
@@ -49,14 +50,16 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     {% endif %}
 
     {% if sent_requests %}
     <h4 style="margin-top: 20px;">Sent</h4>
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>User</th>
@@ -84,7 +87,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     {% endif %}
 </div>

--- a/pickaladder/templates/generated_users.html
+++ b/pickaladder/templates/generated_users.html
@@ -5,7 +5,8 @@
     <h1>Generated Users</h1>
 </div>
 <div class="table-container">
-    <table class="table-standard responsive-table">
+    <div class="table-responsive">
+        <table class="table-standard responsive-table">
         <thead>
             <tr>
                 <th>ID</th>
@@ -30,7 +31,8 @@
             </tr>
             {% endfor %}
         </tbody>
-    </table>
+        </table>
+    </div>
 </div>
 <a href="{{ url_for('admin.admin') }}" class="btn" style="margin-top: 20px;">Back to Admin</a>
 {% endblock %}

--- a/pickaladder/templates/group.html
+++ b/pickaladder/templates/group.html
@@ -67,7 +67,8 @@
                         {% endif %}
                     {% endfor %}
                     <div class="table-container">
-                        <table class="table table-standard responsive-table">
+                        <div class="table-responsive">
+                            <table class="table table-standard responsive-table">
                             <thead>
                                 <tr>
                                     <th class="text-center">Rank</th>
@@ -139,13 +140,15 @@
                                 </tr>
                                 {% endfor %}
                             </tbody>
-                        </table>
+                            </table>
+                        </div>
                     </div>
                 </div>
 
                 <div id="teams" class="tab-content" style="display: none;">
                     <div class="table-container">
-                        <table class="table table-standard responsive-table">
+                        <div class="table-responsive">
+                            <table class="table table-standard responsive-table">
                             <thead>
                                 <tr>
                                     <th class="text-center">Rank</th>
@@ -184,7 +187,8 @@
                                 </tr>
                                 {% endfor %}
                             </tbody>
-                        </table>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -309,7 +313,8 @@
         <div class="manage-group-content">
             <h3>Members</h3>
             <div class="table-container">
-                <table class="table-standard responsive-table">
+                <div class="table-responsive">
+                    <table class="table-standard responsive-table">
                     <tbody>
                         {% for member in members %}
                         <tr class="clickable-row" data-href="{{ url_for('user.view_user', user_id=member.id) }}">
@@ -321,7 +326,8 @@
                         </tr>
                         {% endfor %}
                     </tbody>
-                </table>
+                    </table>
+                </div>
             </div>
 
             {% if group.ownerRef.id == g.user['uid'] %}
@@ -367,7 +373,8 @@
         <div class="manage-group-content">
             <h3>Pending Members</h3>
             <div class="table-container">
-                <table class="table-standard responsive-table">
+                <div class="table-responsive">
+                    <table class="table-standard responsive-table">
                     <thead>
                         <tr>
                             <th class="pending-invites-avatar-header"></th>
@@ -432,7 +439,8 @@
                         </tr>
                         {% endfor %}
                     </tbody>
-                </table>
+                    </table>
+                </div>
             </div>
         </div>
     </details>

--- a/pickaladder/templates/team/view.html
+++ b/pickaladder/templates/team/view.html
@@ -51,7 +51,8 @@
         <div class="card">
             <h3>Recent Matches</h3>
             <div class="table-container">
-                <table class="table-standard responsive-table">
+                <div class="table-responsive">
+                    <table class="table-standard responsive-table">
                     <thead>
                         <tr>
                             <th>Date</th>
@@ -84,7 +85,8 @@
                         </tr>
                         {% endfor %}
                     </tbody>
-                </table>
+                    </table>
+                </div>
             </div>
         </div>
         {% else %}

--- a/pickaladder/templates/tournament/view.html
+++ b/pickaladder/templates/tournament/view.html
@@ -122,7 +122,8 @@
                     <h3 style="margin: 0;">Standings</h3>
                 </div>
                 <div class="table-container">
-                    <table class="table-standard responsive-table">
+                    <div class="table-responsive">
+                        <table class="table-standard responsive-table">
                         <thead>
                             <tr>
                                 <th>Player</th>
@@ -170,7 +171,8 @@
                             <tr><td colspan="3" class="text-center">No participants yet.</td></tr>
                             {% endfor %}
                         </tbody>
-                    </table>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
@@ -179,7 +181,8 @@
             <div class="card">
                 <h3 class="card-header">Participants</h3>
                 <div class="table-container">
-                    <table class="table-standard responsive-table">
+                    <div class="table-responsive">
+                        <table class="table-standard responsive-table">
                         <thead>
                             <tr>
                                 <th>Player</th>
@@ -212,7 +215,8 @@
                                 </tr>
                             {% endfor %}
                         </tbody>
-                    </table>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>

--- a/pickaladder/templates/user/requests.html
+++ b/pickaladder/templates/user/requests.html
@@ -9,7 +9,8 @@
     <h3>Pending Requests</h3>
     {% if requests %}
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>User</th>
@@ -44,7 +45,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     {% else %}
     <p>No pending friend requests.</p>
@@ -55,7 +57,8 @@
     <h3>Sent Requests</h3>
     {% if sent_requests %}
     <div class="table-container">
-        <table class="table-standard responsive-table">
+        <div class="table-responsive">
+            <table class="table-standard responsive-table">
             <thead>
                 <tr>
                     <th>User</th>
@@ -85,7 +88,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     {% else %}
     <p>No sent friend requests.</p>

--- a/pickaladder/templates/user_dashboard.html
+++ b/pickaladder/templates/user_dashboard.html
@@ -204,8 +204,9 @@
                     {% if requests %}
                     <h4 class="fs-xs mb-2">Friend Requests</h4>
                     <div class="table-container shadow-none border mb-3 rounded-sm">
-                        <table class="table mt-0">
-                            <tbody>
+                        <div class="table-responsive">
+                            <table class="table mt-0">
+                                <tbody>
                                 {% for request in requests %}
                                 <tr>
                                     <td class="p-2">
@@ -224,7 +225,8 @@
                                 </tr>
                                 {% endfor %}
                             </tbody>
-                        </table>
+                            </table>
+                        </div>
                     </div>
                     {% endif %}
 

--- a/pickaladder/templates/users.html
+++ b/pickaladder/templates/users.html
@@ -14,7 +14,8 @@
 
 <h3 style="margin-top: 30px;">Friends of Friends</h3>
 <div class="table-container">
-    <table class="table-standard responsive-table">
+    <div class="table-responsive">
+        <table class="table-standard responsive-table">
         <thead>
             <tr>
                 <th>Username</th>
@@ -36,12 +37,14 @@
             </tr>
             {% endfor %}
         </tbody>
-    </table>
+        </table>
+    </div>
 </div>
 
 <h3 style="margin-top: 30px;">All Users</h3>
 <div class="table-container">
-    <table class="table-standard responsive-table">
+    <div class="table-responsive">
+        <table class="table-standard responsive-table">
         <thead>
             <tr>
                 <th></th>
@@ -105,7 +108,8 @@
             </tr>
             {% endfor %}
         </tbody>
-    </table>
+        </table>
+    </div>
 </div>
 
 {% if pagination.pages > 1 %}


### PR DESCRIPTION
Implemented horizontal scrolling for all data tables and refactored the leaderboard grid for mobile devices to prevent viewport breaking and horizontal page scrolling. Added a universal `.table-responsive` utility class and applied it across all relevant templates. Refactored `.leaderboard-row` into a responsive grid that collapses into a stacked layout on small screens.

Fixes #1408

---
*PR created automatically by Jules for task [3830994322482277176](https://jules.google.com/task/3830994322482277176) started by @brewmarsh*