### PR TITLE
Optimize Match Recording for Mobile UX

### DIFF
--- a/pickaladder/static/css/layout-utils.css
+++ b/pickaladder/static/css/layout-utils.css
@@ -98,6 +98,16 @@
     border-radius: var(--radius-md, 8px) !important;
 }
 
+/* --- 6c. Score Input Optimization --- */
+.input-score-massive {
+    font-size: 2rem !important;
+    text-align: center !important;
+    padding: 15px !important;
+    border-radius: var(--radius-lg) !important;
+    font-weight: var(--fw-bold, 700) !important;
+    height: auto !important;
+}
+
 /* Progress Bar */
 .progress {
     display: flex;

--- a/pickaladder/templates/record_match.html
+++ b/pickaladder/templates/record_match.html
@@ -16,35 +16,51 @@
             {{ form.match_type(class="form-control", onchange="toggleFields()") }}
         </div>
 
-        <div class="form-group">
-            {{ form.player1.label }}
-            {{ form.player1(class="form-control") }}
-        </div>
-        <div class="form-group" id="partner-group" style="display: none;">
-            {{ form.partner.label }}
-            {{ form.partner(class="form-control") }}
+        <div class="row">
+            <div class="col-12 col-md-6 mb-3">
+                <div class="form-group mb-0">
+                    {{ form.player1.label }}
+                    {{ form.player1(class="form-control") }}
+                </div>
+            </div>
+            <div class="col-12 col-md-6 mb-3">
+                <div class="form-group mb-0">
+                    <label id="player2-label" for="player2">Opponent</label>
+                    {{ form.player2(class="form-control") }}
+                </div>
+            </div>
         </div>
 
-        <div class="form-group">
-            <label id="player1-score-label" for="player1_score">Your Score</label>
-            {{ form.player1_score(class="form-control") }}
+        <div class="row">
+            <div class="col-12 col-md-6 mb-3" id="partner-group" style="display: none;">
+                <div class="form-group mb-0">
+                    {{ form.partner.label }}
+                    {{ form.partner(class="form-control") }}
+                </div>
+            </div>
+            <div class="col-12 col-md-6 mb-3" id="opponent2-group" style="display: none;">
+                <div class="form-group mb-0">
+                    {{ form.opponent2.label }}
+                    {{ form.opponent2(class="form-control") }}
+                </div>
+            </div>
         </div>
 
         <hr>
 
-        <div class="form-group">
-            <label id="player2-label" for="player2">Opponent</label>
-            {{ form.player2(class="form-control") }}
-        </div>
-
-        <div class="form-group" id="opponent2-group" style="display: none;">
-            {{ form.opponent2.label }}
-            {{ form.opponent2(class="form-control") }}
-        </div>
-
-        <div class="form-group">
-            <label id="player2-score-label" for="player2_score">Opponent's Score</label>
-            {{ form.player2_score(class="form-control") }}
+        <div class="row mt-4">
+            <div class="col-6 text-center">
+                <div class="form-group">
+                    <label id="player1-score-label" for="player1_score" class="fw-bold fs-md">Your Score</label>
+                    {{ form.player1_score(class="form-control input-score-massive", inputmode="numeric", pattern="[0-9]*", placeholder="0") }}
+                </div>
+            </div>
+            <div class="col-6 text-center">
+                <div class="form-group">
+                    <label id="player2-score-label" for="player2_score" class="fw-bold fs-md">Opponent's Score</label>
+                    {{ form.player2_score(class="form-control input-score-massive", inputmode="numeric", pattern="[0-9]*", placeholder="0") }}
+                </div>
+            </div>
         </div>
 
         <hr>


### PR DESCRIPTION
This PR optimizes the Match Recording screen for court-side use on mobile devices. Key changes include:
1. **Tactile Score Inputs:** Introduced a new `.input-score-massive` CSS class that provides 2rem font size, extra padding, and centered text, making it much easier to tap and type scores on small screens.
2. **Mobile-First Player Selection:** Replaced rigid Bootstrap rows with a responsive grid (`col-12 col-md-6`) that ensures player and opponent dropdowns have full-width on mobile to accommodate long names, while maintaining a compact side-by-side view on desktop.
3. **Native Numeric Keypad:** Added `inputmode="numeric"` and `pattern="[0-9]*"` to the score input fields, forcing mobile browsers to open the large numeric keypad instead of the full keyboard.
4. **Improved Desktop Layout:** Adjusted the grid structure so that Player 1 and the primary Opponent sit side-by-side on larger screens, while their respective partners/secondary opponents stack below them, maintaining logical grouping in both singles and doubles modes.

Verified via unit tests (21/21 passed) and visual inspection using mobile/desktop screenshots.

Fixes #1415

---
*PR created automatically by Jules for task [7053859139482163187](https://jules.google.com/task/7053859139482163187) started by @brewmarsh*