### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/pickaladder/templates/components/_tournament_card.html
+++ b/pickaladder/templates/components/_tournament_card.html
@@ -8,7 +8,7 @@
 
     {% if g.user and (g.user.uid == tournament.organizer_id or g.user.isAdmin) %}
     <div class="dropdown kebab-menu" style="position: absolute; top: 10px; right: 10px; z-index: 10;" onclick="event.stopPropagation();">
-        <button class="dropbtn" type="button" style="background: rgba(0,0,0,0.5); color: white; width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; border: none; cursor: pointer;">
+        <button class="dropbtn" type="button" aria-label="Tournament options" aria-haspopup="true" style="background: rgba(0,0,0,0.5); color: white; width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; border: none; cursor: pointer;">
             <i class="fas fa-ellipsis-v"></i>
         </button>
         <div class="dropdown-content">

--- a/pickaladder/templates/match/_challenge_hub.html
+++ b/pickaladder/templates/match/_challenge_hub.html
@@ -1,7 +1,7 @@
 <div class="challenge-hub card shadow-sm mb-4">
     <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
         <h5 class="mb-0"><i class="fas fa-swords me-2"></i>Challenge Hub</h5>
-        <button class="btn btn-sm btn-outline-light" onclick="ChallengeUI.refreshHub()">
+        <button class="btn btn-sm btn-outline-light" aria-label="Refresh challenges" title="Refresh challenges" onclick="ChallengeUI.refreshHub()">
             <i class="fas fa-sync-alt"></i>
         </button>
     </div>

--- a/pickaladder/templates/navbar.html
+++ b/pickaladder/templates/navbar.html
@@ -17,7 +17,7 @@
                     🪙 <span>{{ g.user.social_credits or 100 }}</span>
                 </div>
                 {% endif %}
-                <button class="hamburger-menu">
+                <button class="hamburger-menu" aria-label="Toggle navigation menu" aria-expanded="false">
                     <span></span>
                     <span></span>
                     <span></span>
@@ -80,7 +80,7 @@
                     🪙 <span class="ms-1">{{ g.user.social_credits or 100 }}</span>
                 </div>
                 <div class="dropdown">
-                    <button class="dropbtn">
+                    <button class="dropbtn" aria-label="Open user menu" aria-haspopup="true">
                         <img src="{{ g.user | avatar_url }}" alt="Profile Picture" class="avatar avatar-sm"
                             onerror="this.onerror=null;this.src='{{ url_for('static', filename='user_icon.png') }}';">
                     </button>


### PR DESCRIPTION
💡 What: Added `aria-label`, `aria-haspopup`, and `aria-expanded` to multiple icon-only buttons.
🎯 Why: To improve screen reader accessibility and navigation context for users relying on assistive technologies.
📸 Before/After: Visual changes are minimal/invisible, but DOM structure is now compliant with basic ARIA guidelines.
♿ Accessibility:
- Added `aria-label="Toggle navigation menu"` and `aria-expanded="false"` to hamburger menu.
- Added `aria-label="Open user menu"` and `aria-haspopup="true"` to navbar user dropdown.
- Added `aria-label="Tournament options"` and `aria-haspopup="true"` to tournament card kebab menu.
- Added `aria-label="Refresh challenges"` and `title="Refresh challenges"` to challenge hub sync button.

---
*PR created automatically by Jules for task [2108893577507316753](https://jules.google.com/task/2108893577507316753) started by @brewmarsh*