### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/pickaladder/templates/marketplace/index.html
+++ b/pickaladder/templates/marketplace/index.html
@@ -80,7 +80,7 @@
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary w-100">Filter</button>
                         {% if search_term or search_type != 'all' %}
-                        <a href="{{ url_for('marketplace.view_marketplace') }}" class="btn btn-secondary"><i class="fas fa-times"></i></a>
+                        <a href="{{ url_for('marketplace.view_marketplace') }}" class="btn btn-secondary" aria-label="Clear filters"><i class="fas fa-times"></i></a>
                         {% endif %}
                     </div>
                 </div>

--- a/pickaladder/templates/tournament/view.html
+++ b/pickaladder/templates/tournament/view.html
@@ -370,7 +370,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h3>Select Partner</h3>
-            <button type="button" class="btn-close" onclick="closePartnerModal()">×</button>
+            <button type="button" class="btn-close" aria-label="Close" onclick="closePartnerModal()">×</button>
         </div>
         <div class="modal-body">
             <form id="registerTeamForm" action="{{ url_for('tournament.register_team', tournament_id=tournament.id) }}" method="POST">


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons

💡 What: Added ARIA labels to icon-only buttons/links.
🎯 Why: To improve screen reader accessibility and ensure that buttons without text labels have an accessible name.
♿ Accessibility: Improved WCAG compliance by providing accessible names for interactive elements.

---
*PR created automatically by Jules for task [2406095513620480672](https://jules.google.com/task/2406095513620480672) started by @brewmarsh*