### PR TITLE
🎨 Palette: Add accessibility attributes to friend request buttons

### DIFF
--- a/pickaladder/templates/dashboard.html
+++ b/pickaladder/templates/dashboard.html
@@ -88,11 +88,11 @@
                                     <div class="d-flex gap-1 flex-shrink-0 mt-1 mt-sm-0">
                                         <form action="{{ url_for('user.accept_friend_request', friend_id=request[0]) }}" method="post">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                            <button type="submit" class="btn btn-sm btn-volt p-1 px-2">✓</button>
+                                            <button type="submit" class="btn btn-sm btn-volt p-1 px-2" title="Accept" aria-label="Accept">✓</button>
                                         </form>
                                         <form action="{{ url_for('user.decline_friend_request', friend_id=request[0]) }}" method="post">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                            <button type="submit" class="btn btn-sm btn-outline-danger p-1 px-2">×</button>
+                                            <button type="submit" class="btn btn-sm btn-outline-danger p-1 px-2" title="Decline" aria-label="Decline">×</button>
                                         </form>
                                     </div>
                                 </div>


### PR DESCRIPTION
Added `aria-label` and `title` to the icon-only friend request buttons (Accept/Decline) on the user dashboard.

**💡 What:** The UX enhancement added `title` and `aria-label` attributes to the "✓" and "×" friend request buttons in `pickaladder/templates/dashboard.html`.
**🎯 Why:** The user problem it solves is the lack of context for these icon-only buttons. Screen readers could not describe their purpose, and sighted users might not immediately recognize what the symbols mean without hover text.
**♿ Accessibility:** Screen readers will now announce "Accept" and "Decline" when these buttons are focused. Sighted users will see hover tooltips explaining the actions.

---
*PR created automatically by Jules for task [11826911203748457374](https://jules.google.com/task/11826911203748457374) started by @brewmarsh*