### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label to impersonate button

### DIFF
--- a/pickaladder/templates/users.html
+++ b/pickaladder/templates/users.html
@@ -81,7 +81,7 @@
                     {% endif %}
 
                     {% if g.user.is_admin %}
-                    <a href="{{ url_for('admin.impersonate', user_id=user.id) }}" class="btn btn-info" title="Impersonate">
+                    <a href="{{ url_for('admin.impersonate', user_id=user.id) }}" class="btn btn-info" title="Impersonate" aria-label="Impersonate user">
                         <i class="fa fa-user-secret"></i>
                     </a>
                     <a href="{{ url_for('admin.delete_user', user_id=user.id) }}" class="btn btn-danger">Delete</a>


### PR DESCRIPTION
Added `aria-label="Impersonate user"` to the icon-only "Impersonate" button in `pickaladder/templates/users.html`. This ensures that screen readers provide proper context for this action to users with accessibility needs.

---
*PR created automatically by Jules for task [1765589416164160745](https://jules.google.com/task/1765589416164160745) started by @brewmarsh*