### PR TITLE
⚡ Bolt: [performance improvement] - Optimize get_team_names with db.get_all

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-21 - Avoiding Redundant Database Reads Post-Transaction
 **Learning:** In the Python Firebase Admin SDK, `@firestore.transactional` decorated functions can return values. When updating a document in a transaction, if subsequent application logic (such as notifications) requires data from that document, it is a significant performance anti-pattern to perform a separate `document.get()` immediately after the transaction.
 **Action:** Always return the fetched `DocumentSnapshot` data (e.g., `doc.to_dict()`) directly from the transaction block so it can be reused in the synchronous control flow, eliminating an entire database round-trip.
+## 2025-02-21 - Resolving N+1 Query in `get_team_names`
+**Learning:** In `pickaladder/match/services/query.py`, the `get_team_names` method previously performed two sequential `db.collection("teams").document(id).get()` calls to fetch team names, resulting in an N+1 query bottleneck.
+**Action:** Replaced sequential queries with a single batch fetch using `db.get_all(refs)`. Mapped the result to a dictionary (`{doc.id: doc for doc in db.get_all(refs)}`) to ensure the correct team documents are assigned safely, regardless of the order they are returned, thus halving the database network overhead for this lookup.

--- a/pickaladder/match/services/query.py
+++ b/pickaladder/match/services/query.py
@@ -173,11 +173,18 @@ class MatchQueryService(
     @staticmethod
     def get_team_names(db: Client, team1_id: str, team2_id: str) -> tuple[str, str]:
         """Fetch names for two teams."""
-        t1 = cast("DocumentSnapshot", db.collection("teams").document(team1_id).get())
-        t2 = cast("DocumentSnapshot", db.collection("teams").document(team2_id).get())
+        refs = [
+            db.collection("teams").document(team1_id),
+            db.collection("teams").document(team2_id),
+        ]
+        docs = {doc.id: doc for doc in db.get_all(refs)}
+
+        t1 = cast("DocumentSnapshot", docs.get(team1_id))
+        t2 = cast("DocumentSnapshot", docs.get(team2_id))
+
         return (
-            (t1.to_dict() or {}).get("name", "Team 1") if t1.exists else "Team 1",
-            (t2.to_dict() or {}).get("name", "Team 2") if t2.exists else "Team 2",
+            (t1.to_dict() or {}).get("name", "Team 1") if t1 and t1.exists else "Team 1",
+            (t2.to_dict() or {}).get("name", "Team 2") if t2 and t2.exists else "Team 2",
         )
 
     @staticmethod

--- a/pickaladder/match/services/query.py
+++ b/pickaladder/match/services/query.py
@@ -183,8 +183,12 @@ class MatchQueryService(
         t2 = cast("DocumentSnapshot", docs.get(team2_id))
 
         return (
-            (t1.to_dict() or {}).get("name", "Team 1") if t1 and t1.exists else "Team 1",
-            (t2.to_dict() or {}).get("name", "Team 2") if t2 and t2.exists else "Team 2",
+            (t1.to_dict() or {}).get("name", "Team 1")
+            if t1 and t1.exists
+            else "Team 1",
+            (t2.to_dict() or {}).get("name", "Team 2")
+            if t2 and t2.exists
+            else "Team 2",
         )
 
     @staticmethod


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What: Refactored `MatchQueryService.get_team_names` in `pickaladder/match/services/query.py` to use a batch fetch via `db.get_all(refs)` instead of making two sequential `.get()` queries.
🎯 Why: To resolve an N+1 query pattern where two network round-trips were made instead of one when fetching names for two teams. This improves latency when viewing matches involving teams.
📊 Impact: Cuts the database network overhead for `get_team_names` in half, reducing latency.
🔬 Measurement: Verify that unit tests for matches continue to pass. E2E tests for matches will also remain successful.

---
*PR created automatically by Jules for task [18256653713817889713](https://jules.google.com/task/18256653713817889713) started by @brewmarsh*