### PR TITLE
⚡ Bolt: [performance improvement] Parallelize admin stats aggregations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-02-21 - Optimizing Sequential Database Aggregations
 **Learning:** Replacing server-side `count()` aggregations with client-side document streaming to avoid sequential blocking I/O is a severe anti-pattern that drastically increases database cost and risks OOM crashes.
 **Action:** The correct approach to optimize multiple independent Firestore `count()` queries is to parallelize them using a thread pool (e.g., `concurrent.futures.ThreadPoolExecutor`), preserving the efficiency of server-side counting while minimizing overall latency.
+## 2025-02-21 - Parallelizing Sequential `.count().get()` Aggregations
+**Learning:** Sequential `.count().get()` aggregations in Firestore lead to severe N+1 latency problems because each query blocks the main thread waiting for network response.
+**Action:** When making multiple independent `.count().get()` aggregations in Firestore, always use `concurrent.futures.ThreadPoolExecutor` to execute them concurrently, drastically reducing overall execution time.

--- a/pickaladder/admin/services.py
+++ b/pickaladder/admin/services.py
@@ -17,29 +17,46 @@ class AdminService:
 
         Uses efficient count aggregations.
         """
-        # Total Users
-        total_users = db.collection("users").count().get()[0][0].value
+        import concurrent.futures
 
-        # Active Tournaments (status != 'Completed')
-        active_tournaments = (
-            db.collection("tournaments")
-            .where(filter=firestore.FieldFilter("status", "!=", "Completed"))
-            .count()
-            .get()[0][0]
-            .value
-        )
+        def get_total_users() -> int:
+            return db.collection("users").count().get()[0][0].value
 
-        # Recent Matches (last 24 hours)
-        yesterday = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            days=1,
-        )
-        recent_matches = (
-            db.collection("matches")
-            .where(filter=firestore.FieldFilter("createdAt", ">=", yesterday))
-            .count()
-            .get()[0][0]
-            .value
-        )
+        def get_active_tournaments() -> int:
+            return (
+                db.collection("tournaments")
+                .where(filter=firestore.FieldFilter("status", "!=", "Completed"))
+                .count()
+                .get()[0][0]
+                .value
+            )
+
+        def get_recent_matches() -> int:
+            yesterday = datetime.datetime.now(
+                datetime.timezone.utc
+            ) - datetime.timedelta(
+                days=1,
+            )
+            return (
+                db.collection("matches")
+                .where(filter=firestore.FieldFilter("createdAt", ">=", yesterday))
+                .count()
+                .get()[0][0]
+                .value
+            )
+
+        # ⚡ Bolt Optimization:
+        # What: Execute independent database count queries concurrently instead of sequentially.
+        # Why: Resolves a latency bottleneck where each query waits for the previous one to complete.
+        # Impact: Expected to reduce total latency for this aggregation block by ~2-3x.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            total_users_future = executor.submit(get_total_users)
+            active_tournaments_future = executor.submit(get_active_tournaments)
+            recent_matches_future = executor.submit(get_recent_matches)
+
+            total_users = total_users_future.result()
+            active_tournaments = active_tournaments_future.result()
+            recent_matches = recent_matches_future.result()
 
         return {
             "total_users": total_users,


### PR DESCRIPTION
💡 What: Modified `get_admin_stats` to run the three independent Firestore `.count().get()` queries (`total_users`, `active_tournaments`, `recent_matches`) concurrently using a `ThreadPoolExecutor`, rather than executing them sequentially.

🎯 Why: Resolves an N+1 latency bottleneck in the admin dashboard where each count query had to wait for the previous one to finish before starting.

📊 Impact: Reduces total database round-trip time for fetching admin statistics by roughly 2-3x since the queries execute in parallel.

🔬 Measurement: Verify by executing `make test` or `uv run pytest tests/` which tests these operations and checking load time on the admin dashboard. Run `uv run ruff check` to ensure correctness.

---
*PR created automatically by Jules for task [6405130453745953932](https://jules.google.com/task/6405130453745953932) started by @brewmarsh*