### PR TITLE
⚡ Bolt: [performance improvement] Parallelize admin stats queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,9 @@
 ## 2025-02-21 - Optimizing Sequential Database Aggregations
 **Learning:** Replacing server-side `count()` aggregations with client-side document streaming to avoid sequential blocking I/O is a severe anti-pattern that drastically increases database cost and risks OOM crashes.
 **Action:** The correct approach to optimize multiple independent Firestore `count()` queries is to parallelize them using a thread pool (e.g., `concurrent.futures.ThreadPoolExecutor`), preserving the efficiency of server-side counting while minimizing overall latency.
+## 2026-07-23 - Safe parallelization of I/O bound Firebase requests
+**Learning:** The `google-cloud-firestore` Python client is thread-safe, making it safe to reuse a single `db` client instance across threads in a `ThreadPoolExecutor`. This is extremely useful for parallelizing independent Firestore operations, such as sequential  queries.
+**Action:** When you identify sequential and independent Firestore operations (like aggregations or disjoint queries), use `concurrent.futures.ThreadPoolExecutor` to execute them concurrently, drastically reducing the total latency from a sum of all request times to approximately the longest single request time.
+## 2026-07-23 - Safe parallelization of I/O bound Firebase requests
+**Learning:** The `google-cloud-firestore` Python client is thread-safe, making it safe to reuse a single `db` client instance across threads in a `ThreadPoolExecutor`. This is extremely useful for parallelizing independent Firestore operations, such as sequential `.count().get()` queries.
+**Action:** When you identify sequential and independent Firestore operations (like aggregations or disjoint queries), use `concurrent.futures.ThreadPoolExecutor` to execute them concurrently, drastically reducing the total latency from a sum of all request times to approximately the longest single request time.

--- a/pickaladder/admin/services.py
+++ b/pickaladder/admin/services.py
@@ -15,31 +15,48 @@ class AdminService:
     def get_admin_stats(db: firestore.Client) -> dict[str, Any]:
         """Fetch high-level stats for the admin dashboard.
 
-        Uses efficient count aggregations.
+        Uses efficient count aggregations concurrently.
         """
-        # Total Users
-        total_users = db.collection("users").count().get()[0][0].value
+        import concurrent.futures
 
-        # Active Tournaments (status != 'Completed')
-        active_tournaments = (
-            db.collection("tournaments")
-            .where(filter=firestore.FieldFilter("status", "!=", "Completed"))
-            .count()
-            .get()[0][0]
-            .value
-        )
+        def get_total_users() -> int:
+            return db.collection("users").count().get()[0][0].value
 
-        # Recent Matches (last 24 hours)
-        yesterday = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            days=1,
-        )
-        recent_matches = (
-            db.collection("matches")
-            .where(filter=firestore.FieldFilter("createdAt", ">=", yesterday))
-            .count()
-            .get()[0][0]
-            .value
-        )
+        def get_active_tournaments() -> int:
+            return (
+                db.collection("tournaments")
+                .where(filter=firestore.FieldFilter("status", "!=", "Completed"))
+                .count()
+                .get()[0][0]
+                .value
+            )
+
+        def get_recent_matches() -> int:
+            yesterday = datetime.datetime.now(
+                datetime.timezone.utc
+            ) - datetime.timedelta(
+                days=1,
+            )
+            return (
+                db.collection("matches")
+                .where(filter=firestore.FieldFilter("createdAt", ">=", yesterday))
+                .count()
+                .get()[0][0]
+                .value
+            )
+
+        # ⚡ Bolt Optimization:
+        # What: Execute independent database count queries concurrently instead of sequentially.
+        # Why: Resolves an N+1 latency bottleneck where each query waits for the previous one to complete.
+        # Impact: Expected to reduce total latency for this aggregation block by ~2-3x.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            total_users_future = executor.submit(get_total_users)
+            active_tournaments_future = executor.submit(get_active_tournaments)
+            recent_matches_future = executor.submit(get_recent_matches)
+
+            total_users = total_users_future.result()
+            active_tournaments = active_tournaments_future.result()
+            recent_matches = recent_matches_future.result()
 
         return {
             "total_users": total_users,


### PR DESCRIPTION
💡 What: Modified `get_admin_stats` in `pickaladder/admin/services.py` to execute three independent `.count().get()` Firestore queries concurrently using a `ThreadPoolExecutor`.
🎯 Why: The original implementation executed these aggregations sequentially, creating an N+1 latency bottleneck where each query had to wait for the previous one to finish before starting.
📊 Impact: Expected to reduce total latency for this admin aggregation block by roughly ~2-3x, bringing it closer to the latency of a single query.
🔬 Measurement: Verify by executing the admin dashboard tests (`pytest tests/test_admin.py`) and observing the response times in production metrics for the admin landing page.

---
*PR created automatically by Jules for task [6907830945948751244](https://jules.google.com/task/6907830945948751244) started by @brewmarsh*