### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to admin form inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-07-06 - ARIA Expanded State on Dropdown Triggers
 **Learning:** Script-driven toggles (like hamburger menus) often lack state indication for screen readers. While `aria-haspopup="true"` signals that a menu exists, screen reader users do not know whether the menu is currently open or closed without the `aria-expanded` attribute. Note that pure CSS dropdowns shouldn't have a static `aria-expanded="false"` because it won't update when the menu opens on hover/focus.
 **Action:** For script-driven menus, ensure the JavaScript toggles the `aria-expanded` attribute between "true" and "false" when the menu's visibility changes, as demonstrated in `navbar.js`. Do not add static `aria-expanded="false"` to pure CSS dropdowns.
+## 2026-07-24 - ARIA labels on Admin form inputs
+**Learning:** Found that form inputs within administrative panels (like the "Merge Ghost" or "Delete User" forms in `admin.html`) often lacked proper `<label>` elements and `aria-label` attributes, relying entirely on visual placeholders. Since these tools are destructive or highly privileged, accessibility and clarity are paramount.
+**Action:** Added explicit `aria-label` attributes to the inputs for "Real User ID", "Ghost Email", and "User ID or Email" to provide essential context for screen reader users and prevent reliance on transient placeholder text.

--- a/pickaladder/templates/admin/admin.html
+++ b/pickaladder/templates/admin/admin.html
@@ -122,8 +122,8 @@
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="form-group">
                     <input type="text" name="target_user_id" class="form-control mb-2" placeholder="Real User ID"
-                        required>
-                    <input type="email" name="ghost_email" class="form-control mb-2" placeholder="Ghost Email" required>
+                        aria-label="Real User ID" required>
+                    <input type="email" name="ghost_email" class="form-control mb-2" placeholder="Ghost Email" aria-label="Ghost Email" required>
                 </div>
                 <button type="submit" class="btn btn-secondary w-100">Merge Ghost</button>
             </form>
@@ -190,7 +190,7 @@
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="form-group mb-2">
                     <input type="text" id="user_identifier" name="user_identifier" class="form-control form-control-sm"
-                        placeholder="User ID or Email" required>
+                        placeholder="User ID or Email" aria-label="User ID or Email" required>
                 </div>
                 <button type="submit" class="btn btn-danger btn-sm w-100">Delete User</button>
             </form>


### PR DESCRIPTION
💡 **What**: Added explicit `aria-label` attributes to the "Real User ID", "Ghost Email", and "User ID or Email" input fields in the admin interface (`admin.html`).
🎯 **Why**: These input fields lacked associated `<label>` elements and relied entirely on `placeholder` attributes. This made them inaccessible to screen readers, which often ignore placeholders or lose them once text is entered. Given these are destructive or highly privileged admin actions, clear accessible names are crucial.
♿ **Accessibility**: Improved screen reader support for critical administrative inputs by providing explicit context (WCAG 4.1.2 Name, Role, Value).

---
*PR created automatically by Jules for task [6008254212712228018](https://jules.google.com/task/6008254212712228018) started by @brewmarsh*