### PR TITLE
⚡ Bolt: [performance improvement] Prevent redundant Firestore queries in candidate selection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-02-21 - Optimizing Sequential Database Aggregations
 **Learning:** Replacing server-side `count()` aggregations with client-side document streaming to avoid sequential blocking I/O is a severe anti-pattern that drastically increases database cost and risks OOM crashes.
 **Action:** The correct approach to optimize multiple independent Firestore `count()` queries is to parallelize them using a thread pool (e.g., `concurrent.futures.ThreadPoolExecutor`), preserving the efficiency of server-side counting while minimizing overall latency.
+## 2024-05-14 - Prevent Redundant Firestore Queries in Match Validation
+**Learning:** In scenarios where one candidate list is a subset of another (e.g., one including the user and one excluding the user), making two identical Firestore queries with slightly different filters is an anti-pattern that creates unnecessary N+1 query bottlenecks.
+**Action:** When fetching multiple candidate player sets, query the database once with `include_user=True` and derive the secondary set in-memory by creating a copy and removing the user ID using `.copy()` and `.discard(user_id)`. This prevents redundant reads and improves match recording performance.

--- a/pickaladder/match/routes.py
+++ b/pickaladder/match/routes.py
@@ -93,13 +93,11 @@ def _populate_match_form_choices(  # noqa: PLR0913
         session_id,
         True,
     )
-    other_cands = MatchQueryService.get_candidate_player_ids(
-        db,
-        user_id,
-        group_id,
-        t_id,
-        session_id,
-    )
+
+    # ⚡ Bolt: Prevent redundant Firestore query by deriving other_cands in-memory
+    other_cands = p1_cands.copy()
+    other_cands.discard(user_id)
+
     all_uids = p1_cands | other_cands
     all_names = {}
     if all_uids:

--- a/pickaladder/match/services/match_validation.py
+++ b/pickaladder/match/services/match_validation.py
@@ -41,13 +41,6 @@ class MatchValidationService:
     @staticmethod
     def _check_player_validity(db: Client, sub: MatchSubmission, user_id: str) -> None:
         """Validate that all players are valid candidates."""
-        cands = MatchQueryService.get_candidate_player_ids(
-            db,
-            user_id,
-            sub.group_id,
-            sub.tournament_id,
-            sub.session_id,
-        )
         p1_cands = MatchQueryService.get_candidate_player_ids(
             db,
             user_id,
@@ -56,6 +49,10 @@ class MatchValidationService:
             sub.session_id,
             True,
         )
+
+        # ⚡ Bolt: Prevent redundant Firestore query by deriving cands in-memory
+        cands = p1_cands.copy()
+        cands.discard(user_id)
 
         if sub.player_1_id not in p1_cands:
             msg = "Invalid Team 1 Player 1 selected."


### PR DESCRIPTION
💡 What: Optimized candidate selection in `pickaladder/match/routes.py` and `pickaladder/match/services/match_validation.py` by deriving the secondary candidate set (`other_cands` / `cands`) in-memory using `.copy()` and `.discard(user_id)` from the first set (`p1_cands`), instead of querying Firestore twice.
🎯 Why: In scenarios where one candidate list is a subset of another (e.g., one including the user and one excluding the user), making two identical Firestore queries with slightly different filters is an anti-pattern that creates unnecessary query bottlenecks.
📊 Impact: Reduces database reads by 50% when loading the record match form and when validating match submissions, improving load times and reducing Firestore costs.
🔬 Measurement: Verified by running the test suite (`uv run pytest tests/`) which ensures that the candidate selection logic is functionally identical to the previous implementation.

---
*PR created automatically by Jules for task [2854516412533048806](https://jules.google.com/task/2854516412533048806) started by @brewmarsh*